### PR TITLE
fuzzing: export StTransaction

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -396,7 +396,7 @@ func ExecuteFuzzer(c *cli.Context, generatorFn GeneratorFn, name string) error {
 }
 
 // storeTest saves a testcase to disk
-func storeTest(location string, test *fuzzing.GeneralStateTest, testName string) (string, error) {
+func StoreTest(location string, test *fuzzing.GeneralStateTest, testName string) (string, error) {
 
 	fileName := fmt.Sprintf("%v.json", testName)
 	fullPath := path.Join(location, fileName)

--- a/fuzzing/copypasta.go
+++ b/fuzzing/copypasta.go
@@ -21,12 +21,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rlp"
 	"golang.org/x/crypto/sha3"
-	"math/big"
 )
 
 // GenesisAlloc specifies the initial state that is part of the genesis block.
@@ -107,7 +108,7 @@ func (t *StateTest) UnmarshalJSON(in []byte) error {
 type stJSON struct {
 	Env  stEnv                    `json:"env"`
 	Pre  GenesisAlloc             `json:"pre"`
-	Tx   stTransaction            `json:"transaction"`
+	Tx   StTransaction            `json:"transaction"`
 	Out  hexutil.Bytes            `json:"out"`
 	Post map[string][]stPostState `json:"post"`
 }
@@ -145,7 +146,7 @@ type stEnvMarshaling struct {
 
 //go:generate gencodec -type stTransaction -field-override stTransactionMarshaling -out gen_sttransaction.go
 
-type stTransaction struct {
+type StTransaction struct {
 	GasPrice   *big.Int `json:"gasPrice"`
 	Nonce      uint64   `json:"nonce"`
 	To         string   `json:"to"`

--- a/fuzzing/gen_sttransaction.go
+++ b/fuzzing/gen_sttransaction.go
@@ -13,7 +13,7 @@ import (
 var _ = (*stTransactionMarshaling)(nil)
 
 // MarshalJSON marshals as JSON.
-func (s stTransaction) MarshalJSON() ([]byte, error) {
+func (s StTransaction) MarshalJSON() ([]byte, error) {
 	type stTransaction struct {
 		GasPrice   *math.HexOrDecimal256 `json:"gasPrice"`
 		Nonce      math.HexOrDecimal64   `json:"nonce"`
@@ -40,7 +40,7 @@ func (s stTransaction) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON unmarshals from JSON.
-func (s *stTransaction) UnmarshalJSON(input []byte) error {
+func (s *StTransaction) UnmarshalJSON(input []byte) error {
 	type stTransaction struct {
 		GasPrice   *math.HexOrDecimal256 `json:"gasPrice"`
 		Nonce      *math.HexOrDecimal64  `json:"nonce"`

--- a/fuzzing/statetest_maker.go
+++ b/fuzzing/statetest_maker.go
@@ -129,7 +129,7 @@ func init() {
 type GstMaker struct {
 	pre   *GenesisAlloc
 	env   *stEnv
-	tx    stTransaction
+	tx    StTransaction
 	forks []string
 	root  common.Hash
 	logs  common.Hash
@@ -206,7 +206,7 @@ func (g *GstMaker) randomFillGenesisAlloc() *common.Address {
 	return dest
 }
 
-func (g *GstMaker) SetTx(tx *stTransaction) {
+func (g *GstMaker) SetTx(tx *StTransaction) {
 	g.tx = *tx
 }
 
@@ -299,7 +299,7 @@ func GenerateStateTest(name string) *GeneralStateTest {
 	dest := gst.randomFillGenesisAlloc()
 	// The transaction
 	{
-		tx := &stTransaction{
+		tx := &StTransaction{
 			// 8M gaslimit
 			GasLimit:   []uint64{8000000},
 			Nonce:      0,
@@ -327,7 +327,7 @@ func GenerateBlake() *GstMaker {
 	})
 	// The transaction
 	{
-		tx := &stTransaction{
+		tx := &StTransaction{
 			// 8M gaslimit
 			GasLimit:   []uint64{8000000},
 			Nonce:      0,
@@ -373,7 +373,7 @@ func Generate2200Test() *GstMaker {
 	}
 	// The transaction
 	{
-		tx := &stTransaction{
+		tx := &StTransaction{
 			// 8M gaslimit
 			GasLimit:   []uint64{8000000},
 			Nonce:      0,
@@ -400,7 +400,7 @@ func GenerateECRecover() (*GstMaker, []byte) {
 	})
 	// The transaction
 	{
-		tx := &stTransaction{
+		tx := &StTransaction{
 			// 8M gaslimit
 			GasLimit:   []uint64{8000000},
 			Nonce:      0,


### PR DESCRIPTION
We export `gst.SetTx()` but the transaction type itself is not exported which makes handling a pain