### PR TITLE
Handle small displays better with single trace view

### DIFF
--- a/cmd/traceview/main.go
+++ b/cmd/traceview/main.go
@@ -19,10 +19,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/holiman/goevmlab/traces"
-	"github.com/holiman/goevmlab/ui"
 	"os"
 	"strconv"
+
+	"github.com/holiman/goevmlab/traces"
+	"github.com/holiman/goevmlab/ui"
 )
 
 func init() {
@@ -35,7 +36,6 @@ Reads the given trace-file, and displays the tracing in a nice CLI user interfac
 }
 
 func main() {
-
 	testTraces := []string{
 		"../../traces/testdata/geth_nomemory.jsonl",
 		"../../traces/testdata/geth_memory.jsonl",
@@ -62,6 +62,5 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
-	mgr := ui.NewViewManager(trace)
-	mgr.Run()
+	ui.NewViewManager(trace)
 }

--- a/ui/viewmanager.go
+++ b/ui/viewmanager.go
@@ -129,7 +129,7 @@ func NewViewManager(trace *traces.Traces) {
 		AddItem(opView, 0, 2, false)
 
 	// Create flex row for lower view.
-	direction := tview.FlexColumn
+	direction := tview.FlexRow
 	lower := tview.NewFlex().SetDirection(direction).
 		AddItem(stack, 0, 1, false).
 		AddItem(mem, 0, 1, false)


### PR DESCRIPTION
Currently when I open a trace in `traceview` using my standard zoom level in my terminal, it looks like this:

![2021-05-12-1620874966_screenshot_1920x1080](https://user-images.githubusercontent.com/14004106/118071701-80dd7d00-b365-11eb-82d5-7e2f2423a53d.jpg)

I modified the UI to use a flexbox instead so that it adapts to different screen sizes better.

![2021-05-12-1620874947_screenshot_1920x1080](https://user-images.githubusercontent.com/14004106/118071817-c5691880-b365-11eb-9919-02128db88d9a.jpg)

I also found that there wasn't a good configuration that allowed me to both see 32 byte values on the stack and reasonable amount of memory, so I added a toggle (`m` key) to change the flex direction on the lower half from columns to rows.

![2021-05-12-1620874951_screenshot_1920x1080](https://user-images.githubusercontent.com/14004106/118071872-e467aa80-b365-11eb-8931-37d70ef2cb20.jpg)
