### PR TITLE
add a "code chunk" column to the trace view

### DIFF
--- a/cmd/traceview/main.go
+++ b/cmd/traceview/main.go
@@ -44,11 +44,17 @@ func main() {
 	}
 
 	hasChunking := flag.Bool("chunking", false, "enable code chunking info in traceview")
+	chunkSize := flag.Uint("chunksize", 31, "size of a code chunk")
 	flag.Parse()
 	if flag.NArg() != 1 {
 		fmt.Printf("Expected one argument\n")
 		flag.Usage()
 		os.Exit(1)
+	}
+	if *chunkSize == 0 {
+		fmt.Printf("Chunk size must be a strictly positive integer\n")
+		flag.Usage()
+		os.Exit(2)
 	}
 
 	fName := flag.Arg(0)
@@ -63,5 +69,5 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
-	ui.NewViewManager(trace, &ui.Config{HasChunking: *hasChunking})
+	ui.NewViewManager(trace, &ui.Config{HasChunking: *hasChunking, ChunkSize: *chunkSize})
 }

--- a/cmd/traceview/main.go
+++ b/cmd/traceview/main.go
@@ -43,6 +43,7 @@ func main() {
 		"../../traces/testdata/14a4a43b4e9759aac86bb0ae7e5926850406ff1c43ea571239563ff781474ae0.json.snappy",
 	}
 
+	hasChunking := flag.Bool("chunking", false, "enable code chunking info in traceview")
 	flag.Parse()
 	if flag.NArg() != 1 {
 		fmt.Printf("Expected one argument\n")
@@ -62,5 +63,5 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
-	ui.NewViewManager(trace)
+	ui.NewViewManager(trace, &ui.Config{HasChunking: *hasChunking})
 }

--- a/cmd/traceview/main.go
+++ b/cmd/traceview/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	hasChunking := flag.Bool("chunking", false, "enable code chunking info in traceview")
-	chunkSize := flag.Uint("chunksize", 31, "size of a code chunk")
+	chunkSize := flag.Uint64("chunksize", 31, "size of a code chunk")
 	flag.Parse()
 	if flag.NArg() != 1 {
 		fmt.Printf("Expected one argument\n")
@@ -56,6 +56,7 @@ func main() {
 		flag.Usage()
 		os.Exit(2)
 	}
+	traces.ChunkSize = *chunkSize
 
 	fName := flag.Arg(0)
 	// Some debugging help here
@@ -69,5 +70,5 @@ func main() {
 		fmt.Printf("Error: %v\n", err)
 		os.Exit(1)
 	}
-	ui.NewViewManager(trace, &ui.Config{HasChunking: *hasChunking, ChunkSize: *chunkSize})
+	ui.NewViewManager(trace, &ui.Config{HasChunking: *hasChunking})
 }

--- a/traces/reader.go
+++ b/traces/reader.go
@@ -30,10 +30,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/golang/snappy"
 	"github.com/holiman/goevmlab/ops"
 	"github.com/holiman/uint256"
-	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 )
 
 type TraceLine struct {
@@ -47,6 +47,9 @@ type Traces struct {
 	Ops  []*TraceLine
 	Errs []string
 }
+
+// Global variable chunk size
+var ChunkSize = uint64(31)
 
 func (traces *Traces) Get(index int) *TraceLine {
 	if index < len(traces.Ops) && index >= 0 {
@@ -73,7 +76,8 @@ func (t *TraceLine) Get(title string) string {
 	switch strings.ToLower(title) {
 	case "step":
 		return fmt.Sprintf("%d", t.step)
-
+	case "chunk":
+		return fmt.Sprintf("%v (0x%x)", op.Pc/ChunkSize, op.Pc/ChunkSize)
 	case "pc":
 		return fmt.Sprintf("%v (0x%x)", op.Pc, op.Pc)
 	case "opname":

--- a/ui/viewmanager.go
+++ b/ui/viewmanager.go
@@ -32,7 +32,6 @@ const (
 
 type Config struct {
 	HasChunking bool
-	ChunkSize   uint
 }
 
 type viewManager struct {
@@ -249,6 +248,10 @@ func (mgr *viewManager) init(trace *traces.Traces) {
 		headings := []string{"step", "pc", "opName", "opCode",
 			"gas", "gasCost", "depth", "refund"}
 
+		if mgr.config.HasChunking {
+			headings = append(headings, "chunk")
+		}
+
 		table.SetSelectable(true, false).
 			SetSelectedFunc(func(row int, column int) {
 				table.GetCell(row, column).SetTextColor(tcell.ColorRed)
@@ -270,12 +273,6 @@ func (mgr *viewManager) init(trace *traces.Traces) {
 					SetAlign(tview.AlignCenter).
 					SetSelectable(false))
 		}
-		if mgr.config.HasChunking {
-			table.SetCell(0, len(headings),
-				tview.NewTableCell(strings.ToUpper("chunk")).
-					SetTextColor(headingCol).
-					SetAlign(tview.AlignCenter))
-		}
 		// Ops table body
 		for i, elem := range trace.Ops {
 			if elem == nil {
@@ -285,13 +282,6 @@ func (mgr *viewManager) init(trace *traces.Traces) {
 			for col, title := range headings {
 				data := elem.Get(title)
 				table.SetCell(row, col, tview.NewTableCell(data))
-
-				if title == "pc" && mgr.config.HasChunking {
-					data := elem.Get("pc")
-					var pc, pch int
-					fmt.Sscanf(data, "%d (%#x)", &pc, &pch)
-					table.SetCell(row, len(headings), tview.NewTableCell(fmt.Sprintf("%d", pc/int(mgr.config.ChunkSize))))
-				}
 			}
 		}
 	}

--- a/ui/viewmanager.go
+++ b/ui/viewmanager.go
@@ -262,6 +262,10 @@ func (mgr *viewManager) init(trace *traces.Traces) {
 					SetAlign(tview.AlignCenter).
 					SetSelectable(false))
 		}
+		table.SetCell(0, len(headings),
+			tview.NewTableCell(strings.ToUpper("chunk")).
+				SetTextColor(headingCol).
+				SetAlign(tview.AlignCenter))
 		// Ops table body
 		for i, elem := range trace.Ops {
 			if elem == nil {
@@ -271,6 +275,13 @@ func (mgr *viewManager) init(trace *traces.Traces) {
 			for col, title := range headings {
 				data := elem.Get(title)
 				table.SetCell(row, col, tview.NewTableCell(data))
+
+				if title == "pc" {
+					data := elem.Get("pc")
+					var pc, pch int
+					fmt.Sscanf(data, "%d (%#x)", &pc, &pch)
+					table.SetCell(row, len(headings), tview.NewTableCell(fmt.Sprintf("%d", pc/31)))
+				}
 			}
 		}
 	}

--- a/ui/viewmanager.go
+++ b/ui/viewmanager.go
@@ -32,6 +32,7 @@ const (
 
 type Config struct {
 	HasChunking bool
+	ChunkSize   uint
 }
 
 type viewManager struct {
@@ -289,7 +290,7 @@ func (mgr *viewManager) init(trace *traces.Traces) {
 					data := elem.Get("pc")
 					var pc, pch int
 					fmt.Sscanf(data, "%d (%#x)", &pc, &pch)
-					table.SetCell(row, len(headings), tview.NewTableCell(fmt.Sprintf("%d", pc/31)))
+					table.SetCell(row, len(headings), tview.NewTableCell(fmt.Sprintf("%d", pc/int(mgr.config.ChunkSize))))
 				}
 			}
 		}


### PR DESCRIPTION
Verkle trees (and other EIPs) introduce the concept of code chunking. I found it useful to add a column to display which chunk a program counter belongs to.

There are some things missing to this PR, which I'm opening to collect feedback:

 - [x] make code chunking a command line option
 - [x] customizable chunk size
 - [ ] ~~improve the chunk calculation, this is Q&D code~~ -> even though I would prefer tackling this in `Traceline::Get`, I would need to pass the config to `Traceline`/`Get` and that's overkill. I have another idea on how to make it more generic, and that's work for another, non-specific PR.

This PR is therefore ready for review/merge.