### PR TITLE
bump version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/holiman/goevmlab
 
-go 1.18
+go 1.19
 
 require (
 	github.com/ethereum/go-ethereum v1.11.1


### PR DESCRIPTION
the use of binary.BigEndian.AppendUint16 was added in go version 1.19