### PR TITLE
evms: make scanner buffer handle up to 32 MB output

### DIFF
--- a/evms/besu.go
+++ b/evms/besu.go
@@ -115,11 +115,8 @@ type besuStateRoot struct {
 func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	// We use a larger scanner buffer for besu: it does not have a way to
-	// disable 'returndata', which can become larger than fits into a default
-	// scanner buffer
-	buf := make([]byte, 16*1024*1024)
-	scanner.Buffer(buf, cap(buf))
+	// Start with 1MB buffer, allow up to 32 MB
+	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		var elem logger.StructLog

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -106,8 +106,8 @@ func (vm *ErigonVM) Close() {
 func (evm *ErigonVM) Copy(out io.Writer, input io.Reader) {
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	buf := make([]byte, 4*1024*1024)
-	scanner.Buffer(buf, cap(buf))
+	// Start with 1MB buffer, allow up to 32 MB
+	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		var elem logger.StructLog

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -107,8 +107,8 @@ func (vm *GethEVM) Close() {
 func (evm *GethEVM) Copy(out io.Writer, input io.Reader) {
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	buf := make([]byte, 4*1024*1024)
-	scanner.Buffer(buf, cap(buf))
+	// Start with 1MB buffer, allow up to 32 MB
+	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
 
 	// When geth encounters an error, it may already have spat out the info, prematurely.
 	// We need to merge it back to one item

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -106,8 +106,8 @@ func (evm *NethermindVM) Copy(out io.Writer, input io.Reader) {
 func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	buf := make([]byte, 4*1024*1024)
-	scanner.Buffer(buf, cap(buf))
+	// Start with 1MB buffer, allow up to 32 MB
+	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		var elem logger.StructLog

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -108,11 +108,8 @@ func (vm *NimbusEVM) Close() {
 func (evm *NimbusEVM) Copy(out io.Writer, input io.Reader) {
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	// We use a larger scanner buffer for besu: it does not have a way to
-	// disable 'returndata', which can become larger than fits into a default
-	// scanner buffer
-	buf := make([]byte, 4*1024*1024)
-	scanner.Buffer(buf, cap(buf))
+	// Start with 1MB buffer, allow up to 32 MB
+	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
 	for scanner.Scan() {
 		data := scanner.Bytes()
 


### PR DESCRIPTION
Should improve stuff: make the initial buffer smaller, but make the max size larger. 