### PR TITLE
cmd/runtest: common: use more parallelism in fuzzer

### DIFF
--- a/cmd/generic-fuzzer/main.go
+++ b/cmd/generic-fuzzer/main.go
@@ -36,7 +36,7 @@ var (
 	forkFlag = &cli.StringFlag{
 		Name:  "fork",
 		Usage: "What fork to use (London, Merge, Byzantium, Shanghai, etc)",
-		Value: "Merge",
+		Value: "Merged",
 	}
 	app = initApp()
 )

--- a/cmd/generic-fuzzer/main.go
+++ b/cmd/generic-fuzzer/main.go
@@ -100,5 +100,5 @@ func startFuzzer(ctx *cli.Context) error {
 			return fn()
 		}
 	}
-	return common.ExecuteFuzzer(ctx, factory, "mixed")
+	return common.GenerateAndExecute(ctx, factory, "mixed")
 }

--- a/cmd/generic-generator/main.go
+++ b/cmd/generic-generator/main.go
@@ -38,8 +38,8 @@ var (
 	}
 	forkFlag = &cli.StringFlag{
 		Name:  "fork",
-		Usage: "What fork to use (London, Merge, Byzantium, Shanghai, etc)",
-		Value: "Merge",
+		Usage: "What fork to use (London, Merged, Byzantium, Shanghai, etc)",
+		Value: "Merged",
 	}
 	app = initApp()
 )

--- a/cmd/minimizer/main.go
+++ b/cmd/minimizer/main.go
@@ -78,7 +78,7 @@ func startFuzzer(c *cli.Context) error {
 	}
 	if c.Bool(fullTraceFlag.Name) {
 		compareFn = func(path string, c *cli.Context) (bool, error) {
-			agree, err := common.RunTests([]string{path}, c)
+			agree, err := common.RunSingleTest(path, c)
 			if !agree {
 				return false, nil
 			}


### PR DESCRIPTION
runtest will use the better parallelism if `--parallel` is provided