### PR TITLE
General speedups, show execution speed metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,8 @@
 run:
   skip-dirs-use-default: false
 
-  skip-dirs:
-    - foo
+  issues:
+    exclude-rules:
+      - linters:
+          - staticcheck
+        text: "SA6002:"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   skip-dirs-use-default: false
 
-  issues:
-    exclude-rules:
-      - linters:
-          - staticcheck
-        text: "SA6002:"
+issues:
+  exclude:
+    - 'SA6002: argument should be pointer-like to avoid allocations'

--- a/cmd/generic-fuzzer/main.go
+++ b/cmd/generic-fuzzer/main.go
@@ -32,6 +32,7 @@ var (
 	engineFlag = &cli.StringSliceFlag{
 		Name:  "engine",
 		Usage: "fuzzing-engine",
+		Value: cli.NewStringSlice(fuzzing.FactoryNames()...),
 	}
 	forkFlag = &cli.StringFlag{
 		Name:  "fork",

--- a/cmd/generic-generator/main.go
+++ b/cmd/generic-generator/main.go
@@ -35,6 +35,7 @@ var (
 	engineFlag = &cli.StringSliceFlag{
 		Name:  "engine",
 		Usage: "fuzzing-engine",
+		Value: cli.NewStringSlice(fuzzing.FactoryNames()...),
 	}
 	forkFlag = &cli.StringFlag{
 		Name:  "fork",

--- a/common/utils.go
+++ b/common/utils.go
@@ -135,28 +135,28 @@ func initVMs(c *cli.Context) []evms.Evm {
 		vms []evms.Evm
 	)
 	for i, bin := range gethBins {
-		vms = append(vms, evms.NewGethEVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewGethEVM(bin, fmt.Sprintf("geth-%d", i)))
 	}
 	for i, bin := range gethBatchBins {
-		vms = append(vms, evms.NewGethBatchVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewGethBatchVM(bin, fmt.Sprintf("gethbatch-%d", i)))
 	}
 	for i, bin := range nethBins {
-		vms = append(vms, evms.NewNethermindVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewNethermindVM(bin, fmt.Sprintf("nethermind-%d", i)))
 	}
 	for i, bin := range nethBatchBins {
-		vms = append(vms, evms.NewNethermindBatchVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewNethermindBatchVM(bin, fmt.Sprintf("nethbatch-%d", i)))
 	}
 	for i, bin := range besuBins {
-		vms = append(vms, evms.NewBesuVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewBesuVM(bin, fmt.Sprintf("besu-%d", i)))
 	}
 	for i, bin := range besuBatchBins {
-		vms = append(vms, evms.NewBesuBatchVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewBesuBatchVM(bin, fmt.Sprintf("besubatch-%d", i)))
 	}
 	for i, bin := range erigonBins {
-		vms = append(vms, evms.NewErigonVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewErigonVM(bin, fmt.Sprintf("erigon-%d", i)))
 	}
 	for i, bin := range nimBins {
-		vms = append(vms, evms.NewNimbusEVM(bin, fmt.Sprintf("%d", i)))
+		vms = append(vms, evms.NewNimbusEVM(bin, fmt.Sprintf("nimbus-%d", i)))
 	}
 	return vms
 

--- a/common/utils.go
+++ b/common/utils.go
@@ -34,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"bufio"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -233,7 +234,9 @@ func RunSingleTest(path string, c *cli.Context) (bool, error) {
 	for i, vm := range vms {
 		go func(evm evms.Evm, i int) {
 			defer wg.Done()
-			res, err := evm.RunStateTest(path, outputs[i], false)
+			bufout := bufio.NewWriter(outputs[i])
+			res, err := evm.RunStateTest(path, bufout, false)
+			bufout.Flush()
 			commands[i] = res.Cmd
 			if err != nil {
 				log.Error("Error running test", "err", err)
@@ -584,7 +587,9 @@ func (meta *testMeta) startTracingTestExecutors(numThreads int) {
 			for i, vm := range meta.vms {
 				go func(evm evms.Evm, i int) {
 					defer vmWg.Done()
-					res, err := evm.RunStateTest(file, outputs[i], false)
+					bufout := bufio.NewWriter(outputs[i])
+					res, err := evm.RunStateTest(file, bufout, false)
+					bufout.Flush()
 					commands[i] = res.Cmd
 					if err != nil {
 						log.Error("Error starting vm", "err", err, "command", res.Cmd)

--- a/common/utils.go
+++ b/common/utils.go
@@ -569,7 +569,7 @@ func (meta *testMeta) startTracingTestExecutors(numThreads int) {
 		}
 		vms := make([]evms.Evm, len(meta.vms))
 		for i, vm := range meta.vms {
-			vms[i] = vm.Instance()
+			vms[i] = vm.Instance(threadId)
 		}
 		for file := range meta.testCh {
 			if meta.abort.Load() {

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -179,5 +179,5 @@ func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *BesuVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -47,7 +47,7 @@ func NewBesuVM(path, name string) *BesuVM {
 	}
 }
 
-func (evm *BesuVM) Instance() Evm {
+func (evm *BesuVM) Instance(int) Evm {
 	return evm
 }
 
@@ -127,10 +127,11 @@ type besuStateRoot struct {
 }
 
 func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
+	buf := bufferPool.Get().([]byte)
+	defer bufferPool.Put(buf)
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	// Start with 1MB buffer, allow up to 32 MB
-	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
+	scanner.Buffer(buf, 32*1024*1024)
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		var elem logger.StructLog

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -128,6 +128,7 @@ type besuStateRoot struct {
 
 func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 	buf := bufferPool.Get().([]byte)
+	//lint:ignore SA6002: argument should be pointer-like to avoid allocations.
 	defer bufferPool.Put(buf)
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -47,6 +47,10 @@ func NewBesuVM(path, name string) *BesuVM {
 	}
 }
 
+func (evm *BesuVM) Instance() Evm {
+	return evm
+}
+
 func (evm *BesuVM) Name() string {
 	return fmt.Sprintf("besu-%v", evm.name)
 }
@@ -174,5 +178,5 @@ func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *BesuVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -52,7 +52,7 @@ func (evm *BesuVM) Instance(int) Evm {
 }
 
 func (evm *BesuVM) Name() string {
-	return fmt.Sprintf("besu-%v", evm.name)
+	return evm.name
 }
 
 // RunStateTest implements the Evm interface

--- a/evms/besubatcher.go
+++ b/evms/besubatcher.go
@@ -45,8 +45,17 @@ func NewBesuBatchVM(path, name string) *BesuBatchVM {
 	}
 }
 
-func (evm *BesuBatchVM) Instance() Evm {
-	return evm
+func (evm *BesuBatchVM) Instance(threadId int) Evm {
+	return &BesuBatchVM{
+		BesuVM: BesuVM{
+			path:  evm.path,
+			name:  fmt.Sprintf("%v-%d", evm.name, threadId),
+			stats: evm.stats,
+		},
+		cmd:    nil,
+		stdout: nil,
+		stdin:  nil,
+	}
 }
 
 func (evm *BesuBatchVM) Name() string {

--- a/evms/besubatcher.go
+++ b/evms/besubatcher.go
@@ -45,6 +45,10 @@ func NewBesuBatchVM(path, name string) *BesuBatchVM {
 	}
 }
 
+func (evm *BesuBatchVM) Instance() Evm {
+	return evm
+}
+
 func (evm *BesuBatchVM) Name() string {
 	return fmt.Sprintf("besubatch-%v", evm.name)
 }

--- a/evms/besubatcher.go
+++ b/evms/besubatcher.go
@@ -32,8 +32,6 @@ type BesuBatchVM struct {
 	stdout io.ReadCloser
 	stdin  io.WriteCloser
 	mu     sync.Mutex
-	// Some metrics
-	stats *VmStat
 }
 
 func NewBesuBatchVM(path, name string) *BesuBatchVM {
@@ -53,9 +51,6 @@ func (evm *BesuBatchVM) Instance(threadId int) Evm {
 			name:  fmt.Sprintf("%v-%d", evm.name, threadId),
 			stats: evm.stats,
 		},
-		cmd:    nil,
-		stdout: nil,
-		stdin:  nil,
 	}
 }
 

--- a/evms/besubatcher.go
+++ b/evms/besubatcher.go
@@ -39,8 +39,9 @@ type BesuBatchVM struct {
 func NewBesuBatchVM(path, name string) *BesuBatchVM {
 	return &BesuBatchVM{
 		BesuVM: BesuVM{
-			path: path,
-			name: name,
+			path:  path,
+			name:  name,
+			stats: new(VmStat),
 		},
 	}
 }
@@ -56,10 +57,6 @@ func (evm *BesuBatchVM) Instance(threadId int) Evm {
 		stdout: nil,
 		stdin:  nil,
 	}
-}
-
-func (evm *BesuBatchVM) Name() string {
-	return fmt.Sprintf("besubatch-%v", evm.name)
 }
 
 // RunStateTest implements the Evm interface

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -164,5 +164,5 @@ func (evm *ErigonVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *ErigonVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -40,8 +40,9 @@ type ErigonVM struct {
 
 func NewErigonVM(path, name string) *ErigonVM {
 	return &ErigonVM{
-		path: path,
-		name: name,
+		path:  path,
+		name:  name,
+		stats: new(VmStat),
 	}
 }
 
@@ -50,7 +51,7 @@ func (evm *ErigonVM) Instance(int) Evm {
 }
 
 func (evm *ErigonVM) Name() string {
-	return fmt.Sprintf("erigon-%v", evm.name)
+	return evm.name
 }
 
 // GetStateRoot runs the test and returns the stateroot

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -45,6 +45,10 @@ func NewErigonVM(path, name string) *ErigonVM {
 	}
 }
 
+func (evm *ErigonVM) Instance() Evm {
+	return evm
+}
+
 func (evm *ErigonVM) Name() string {
 	return fmt.Sprintf("erigon-%v", evm.name)
 }
@@ -159,5 +163,5 @@ func (evm *ErigonVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *ErigonVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -45,7 +45,7 @@ func NewErigonVM(path, name string) *ErigonVM {
 	}
 }
 
-func (evm *ErigonVM) Instance() Evm {
+func (evm *ErigonVM) Instance(int) Evm {
 	return evm
 }
 

--- a/evms/evms.go
+++ b/evms/evms.go
@@ -58,7 +58,12 @@ type stateRoot struct {
 func CompareFiles(vms []Evm, readers []io.Reader) (bool, int) {
 	var scanners []*bufio.Scanner
 	for _, r := range readers {
-		scanners = append(scanners, bufio.NewScanner(r))
+		scanner := bufio.NewScanner(r)
+		buf := bufferPool.Get().([]byte)
+		defer bufferPool.Put(buf)
+		scanner.Buffer(buf, len(buf))
+		scanners = append(scanners, scanner)
+
 	}
 	var (
 		count    = 0

--- a/evms/evms.go
+++ b/evms/evms.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"sync"
 )
 
 // The Evm interface represents external EVM implementations, which can
@@ -45,7 +46,7 @@ type Evm interface {
 	// This method may deliver the same instance each time, but it may also
 	// deliver e.g. a unique version which has preallocated buffers. Such an instance
 	// is not concurrency-safe, but is fine to deliver in this method.
-	Instance() Evm
+	Instance(threadId int) Evm
 }
 
 type stateRoot struct {
@@ -91,4 +92,11 @@ func CompareFiles(vms []Evm, readers []io.Reader) (bool, int) {
 		}
 	}
 	return true, count
+}
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		// A 5Mb buffer
+		return make([]byte, 5*1024*1025)
+	},
 }

--- a/evms/evms.go
+++ b/evms/evms.go
@@ -40,6 +40,12 @@ type Evm interface {
 	Close() // Tear down processes
 	Name() string
 	Stats() []any
+
+	// Instance delivers an instance of the EVM which will be executed per-thread.
+	// This method may deliver the same instance each time, but it may also
+	// deliver e.g. a unique version which has preallocated buffers. Such an instance
+	// is not concurrency-safe, but is fine to deliver in this method.
+	Instance() Evm
 }
 
 type stateRoot struct {

--- a/evms/evms.go
+++ b/evms/evms.go
@@ -60,6 +60,7 @@ func CompareFiles(vms []Evm, readers []io.Reader) (bool, int) {
 	for _, r := range readers {
 		scanner := bufio.NewScanner(r)
 		buf := bufferPool.Get().([]byte)
+		//lint:ignore SA6002: argument should be pointer-like to avoid allocations.
 		defer bufferPool.Put(buf)
 		scanner.Buffer(buf, len(buf))
 		scanners = append(scanners, scanner)

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -155,7 +155,7 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 
 	for scanner.Scan() {
 		data := scanner.Bytes()
-		if len(data) > 1 && data[0] == '#' {
+		if len(data) > 0 && data[0] == '#' {
 			// Output preceded by # is ignored, but can be used for debugging, e.g.
 			// to check that the generated tests cover the intended surface.
 			fmt.Printf("%v: %v\n", evm.Name(), string(data))

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -206,5 +206,5 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *GethEVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -53,7 +53,6 @@ func (evm *GethEVM) Instance(int) Evm {
 
 func (evm *GethEVM) Name() string {
 	return evm.name
-	return fmt.Sprintf("geth-%v", evm.name)
 }
 
 // GetStateRoot runs the test and returns the stateroot
@@ -130,6 +129,7 @@ func (evm *GethEVM) Copy(out io.Writer, input io.Reader) {
 // outputs items onto the channel
 func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 	buf := bufferPool.Get().([]byte)
+	//lint:ignore SA6002: argument should be pointer-like to avoid allocations.
 	defer bufferPool.Put(buf)
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -52,6 +52,7 @@ func (evm *GethEVM) Instance(int) Evm {
 }
 
 func (evm *GethEVM) Name() string {
+	return evm.name
 	return fmt.Sprintf("geth-%v", evm.name)
 }
 

--- a/evms/gethbatcher.go
+++ b/evms/gethbatcher.go
@@ -35,17 +35,16 @@ type GethBatchVM struct {
 
 func NewGethBatchVM(path, name string) *GethBatchVM {
 	return &GethBatchVM{
-		GethEVM: GethEVM{path, name, &VmStat{}, nil},
+		GethEVM: GethEVM{path, name, &VmStat{}},
 	}
 }
 
-func (evm *GethBatchVM) Instance() Evm {
+func (evm *GethBatchVM) Instance(threadId int) Evm {
 	return &GethBatchVM{
 		GethEVM: GethEVM{
-			path:   evm.path,
-			name:   fmt.Sprintf("%v-alt", evm.name),
-			stats:  evm.GethEVM.stats,
-			buffer: make([]byte, 5*1024*1024),
+			path:  evm.path,
+			name:  fmt.Sprintf("%v-%d", evm.name, threadId),
+			stats: evm.GethEVM.stats,
 		},
 		cmd:    nil,
 		stdout: nil,

--- a/evms/gethbatcher.go
+++ b/evms/gethbatcher.go
@@ -52,10 +52,6 @@ func (evm *GethBatchVM) Instance(threadId int) Evm {
 	}
 }
 
-func (evm *GethBatchVM) Name() string {
-	return fmt.Sprintf("gethbatch-%v", evm.name)
-}
-
 // RunStateTest implements the Evm interface
 func (evm *GethBatchVM) RunStateTest(path string, out io.Writer, speedTest bool) (*tracingResult, error) {
 	var (

--- a/evms/gethbatcher.go
+++ b/evms/gethbatcher.go
@@ -44,11 +44,8 @@ func (evm *GethBatchVM) Instance(threadId int) Evm {
 		GethEVM: GethEVM{
 			path:  evm.path,
 			name:  fmt.Sprintf("%v-%d", evm.name, threadId),
-			stats: evm.GethEVM.stats,
+			stats: evm.stats,
 		},
-		cmd:    nil,
-		stdout: nil,
-		stdin:  nil,
 	}
 }
 

--- a/evms/gethbatcher.go
+++ b/evms/gethbatcher.go
@@ -81,7 +81,7 @@ func (evm *GethBatchVM) RunStateTest(path string, out io.Writer, speedTest bool)
 	return &tracingResult{
 			Slow:     slow,
 			ExecTime: duration,
-			Cmd:      cmd.String()},
+			Cmd:      evm.cmd.String()},
 		nil
 }
 

--- a/evms/gethbatcher.go
+++ b/evms/gethbatcher.go
@@ -35,7 +35,21 @@ type GethBatchVM struct {
 
 func NewGethBatchVM(path, name string) *GethBatchVM {
 	return &GethBatchVM{
-		GethEVM: GethEVM{path, name, &VmStat{}},
+		GethEVM: GethEVM{path, name, &VmStat{}, nil},
+	}
+}
+
+func (evm *GethBatchVM) Instance() Evm {
+	return &GethBatchVM{
+		GethEVM: GethEVM{
+			path:   evm.path,
+			name:   fmt.Sprintf("%v-alt", evm.name),
+			stats:  evm.GethEVM.stats,
+			buffer: make([]byte, 5*1024*1024),
+		},
+		cmd:    nil,
+		stdout: nil,
+		stdin:  nil,
 	}
 }
 

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -46,6 +46,10 @@ func NewNethermindVM(path, name string) *NethermindVM {
 	}
 }
 
+func (evm *NethermindVM) Instance() Evm {
+	return evm
+}
+
 func (evm *NethermindVM) Name() string {
 	return fmt.Sprintf("nethermind-%v", evm.name)
 }
@@ -168,5 +172,5 @@ func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot 
 }
 
 func (evm *NethermindVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -119,6 +119,7 @@ func (evm *NethermindVM) Copy(out io.Writer, input io.Reader) {
 
 func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 	buf := bufferPool.Get().([]byte)
+	//lint:ignore SA6002: argument should be pointer-like to avoid allocations.
 	defer bufferPool.Put(buf)
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -51,7 +51,7 @@ func (evm *NethermindVM) Instance(int) Evm {
 }
 
 func (evm *NethermindVM) Name() string {
-	return fmt.Sprintf("nethermind-%v", evm.name)
+	return evm.name
 }
 
 // GetStateRoot runs the test and returns the stateroot

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -174,5 +174,5 @@ func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot 
 }
 
 func (evm *NethermindVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -46,7 +46,7 @@ func NewNethermindVM(path, name string) *NethermindVM {
 	}
 }
 
-func (evm *NethermindVM) Instance() Evm {
+func (evm *NethermindVM) Instance(int) Evm {
 	return evm
 }
 
@@ -118,10 +118,12 @@ func (evm *NethermindVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
+	buf := bufferPool.Get().([]byte)
+	defer bufferPool.Put(buf)
 	var stateRoot stateRoot
 	scanner := bufio.NewScanner(input)
-	// Start with 1MB buffer, allow up to 32 MB
-	scanner.Buffer(make([]byte, 1024*1024), 32*1024*1024)
+	scanner.Buffer(buf, 32*1024*1024)
+
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		var elem logger.StructLog

--- a/evms/nethermindbatcher.go
+++ b/evms/nethermindbatcher.go
@@ -39,6 +39,19 @@ func NewNethermindBatchVM(path, name string) *NethermindBatchVM {
 	}
 }
 
+func (evm *NethermindBatchVM) Instance(threadId int) Evm {
+	return &NethermindBatchVM{
+		NethermindVM: NethermindVM{
+			path:  evm.path,
+			name:  fmt.Sprintf("%v-%d", evm.name, threadId),
+			stats: evm.stats,
+		},
+		cmd:    nil,
+		stdout: nil,
+		stdin:  nil,
+	}
+}
+
 func (evm *NethermindBatchVM) Name() string {
 	return fmt.Sprintf("nethbatch-%v", evm.name)
 }

--- a/evms/nethermindbatcher.go
+++ b/evms/nethermindbatcher.go
@@ -46,14 +46,7 @@ func (evm *NethermindBatchVM) Instance(threadId int) Evm {
 			name:  fmt.Sprintf("%v-%d", evm.name, threadId),
 			stats: evm.stats,
 		},
-		cmd:    nil,
-		stdout: nil,
-		stdin:  nil,
 	}
-}
-
-func (evm *NethermindBatchVM) Name() string {
-	return fmt.Sprintf("nethbatch-%v", evm.name)
 }
 
 // RunStateTest implements the Evm interface

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -161,5 +161,5 @@ func (evm *NimbusEVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *NimbusEVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -46,7 +46,7 @@ func NewNimbusEVM(path string, name string) *NimbusEVM {
 	}
 }
 
-func (evm *NimbusEVM) Instance() Evm {
+func (evm *NimbusEVM) Instance(int) Evm {
 	return evm
 }
 

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -46,6 +46,10 @@ func NewNimbusEVM(path string, name string) *NimbusEVM {
 	}
 }
 
+func (evm *NimbusEVM) Instance() Evm {
+	return evm
+}
+
 func (evm *NimbusEVM) Name() string {
 	return fmt.Sprintf("nimb-%v", evm.name)
 }
@@ -157,5 +161,5 @@ func (evm *NimbusEVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *NimbusEVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()), "longest", evm.stats.longestTracingTime}
 }

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -51,7 +51,7 @@ func (evm *NimbusEVM) Instance(int) Evm {
 }
 
 func (evm *NimbusEVM) Name() string {
-	return fmt.Sprintf("nimb-%v", evm.name)
+	return evm.name
 }
 
 // GetStateRoot runs the test and returns the stateroot

--- a/evms/vmstats.go
+++ b/evms/vmstats.go
@@ -4,25 +4,26 @@ import (
 	"time"
 
 	"github.com/holiman/goevmlab/utils"
+	"sync/atomic"
 )
 
 type VmStat struct {
 	// Some metrics
 	tracingSpeedWMA    utils.SlidingAverage
 	longestTracingTime time.Duration
-	numExecs           int
+	numExecs           atomic.Uint64
 }
 
 // TraceDone marks the tracing speed metric, and returns 'true' if the test is
 // 'slow'.
 func (stat *VmStat) TraceDone(start time.Time) (time.Duration, bool) {
-	stat.numExecs++
+	numexecs := stat.numExecs.Add(1)
 	duration := time.Since(start)
 	stat.tracingSpeedWMA.Add(int(duration))
 	if duration > stat.longestTracingTime {
 		stat.longestTracingTime = duration
 		// Don't count the first 500 runs, let it accumulate.
-		if stat.numExecs > 500 {
+		if numexecs > 500 {
 			return duration, true
 		}
 	}

--- a/utils/wma.go
+++ b/utils/wma.go
@@ -1,63 +1,26 @@
 package utils
 
-// MovingAverage implements a simplistic non-threadsafe windowed moving average.
-// The implementation will give erroneous values until the window is filled.
-type MovingAverage struct {
-	values []int
-	idx    int
-}
-
-func NewMovingAverage(windowSize int) *MovingAverage {
-	return &MovingAverage{
-		values: make([]int, windowSize),
-	}
-}
-
-func (ma *MovingAverage) Add(value int) {
-	ma.values[ma.idx] = value
-	ma.idx++
-	ma.idx %= len(ma.values)
-}
-
-func (ma *MovingAverage) Avg() float64 {
-	var sum int
-	for _, v := range ma.values {
-		sum += v
-	}
-	return float64(sum) / float64(len(ma.values))
-}
-
-func (ma *MovingAverage) Max() int {
-	max := ma.values[0]
-	for _, v := range ma.values {
-		if v > max {
-			max = v
-		}
-	}
-	return max
-}
-func (ma *MovingAverage) Min() int {
-	min := ma.values[0]
-	for _, v := range ma.values {
-		if v < min {
-			min = v
-		}
-	}
-	return min
-}
+import (
+	"math"
+	"sync/atomic"
+)
 
 // SlidingAverage implements a decaying moving average.
-type SlidingAverage float64
+type SlidingAverage struct {
+	val atomic.Uint64
+}
 
 func NewSlidingAverage() *SlidingAverage {
 	var x SlidingAverage
 	return &x
 }
 
-func (sa *SlidingAverage) Add(value int) {
-	*sa = SlidingAverage(0.95*float64(*sa) + 0.05*float64(value))
+func (sa *SlidingAverage) Add(sample int) {
+	current := math.Float64frombits(sa.val.Load())
+	updated := 0.95*current + 0.05*float64(sample)
+	sa.val.Store(math.Float64bits(updated))
 }
 
 func (sa *SlidingAverage) Avg() float64 {
-	return float64(*sa)
+	return math.Float64frombits(sa.val.Load())
 }


### PR DESCRIPTION
This change makes things quite a bit faster, by making per-thread local instances
of the batched evms.

This means that each test executor can have it's local instance of the vm-batcher and thus
there is no locking contention around running statetest.

This PR also uses bufio writers, and a scanner-buffers from a `sync.Pool`. 

This commit also makes the sliding average concurrency-safe.