### PR TITLE
fuzzing: faster marshalling and comparison-phase due to less IO

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -17,9 +17,13 @@
 package common
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"io"
 	"math/big"
 	"os"
@@ -34,7 +38,6 @@ import (
 	"syscall"
 	"time"
 
-	"bufio"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
@@ -536,61 +539,54 @@ func (meta *testMeta) startTestExecutors(numThreads int, skipTrace bool) {
 }
 
 func (meta *testMeta) startTracingTestExecutors(numThreads int) {
-	executors := int64(0)
+	var executors atomic.Int64
 
 	execute := func(threadId int) {
 		log.Info("Test executor routine started", "id", threadId)
+		executors.Add(1)
 		defer meta.wg.Done()
 		defer func() {
 			// clean-up tasks
-			if f := atomic.AddInt64(&executors, -1); f == 0 {
+			if f := executors.Add(-1); f == 0 {
 				close(meta.removeCh)
 				close(meta.slowCh)
 				log.Info("Last executor exiting")
 			}
 		}()
-		// Output files are used, the vms spit out their traces to these files.
-		var outputs []*os.File
-		var commands = make([]string, len(meta.vms))
-		defer func() {
-			for _, f := range outputs {
-				f.Close()
-			}
-		}()
-		atomic.AddInt64(&executors, 1)
+		var (
+			commands = make([]string, len(meta.vms))
+			outputs  []*dualWriter
+			vms      []evms.Evm
+		)
 		// Open/create outputs for writing
 		for _, evm := range meta.vms {
-			if out, err := os.OpenFile(fmt.Sprintf("./%v-output-%d.jsonl", evm.Name(), threadId), os.O_CREATE|os.O_RDWR, 0755); err != nil {
+			out, err := os.OpenFile(fmt.Sprintf("./%v-output-%d.jsonl", evm.Name(), threadId), os.O_CREATE|os.O_RDWR, 0755)
+			if err != nil {
 				log.Error("Failed opening file", "err", err)
 				return
-			} else {
-				outputs = append(outputs, out)
 			}
+			defer out.Close()
+			outputs = append(outputs, newDualWriter(out))
 		}
-		vms := make([]evms.Evm, len(meta.vms))
-		for i, vm := range meta.vms {
-			vms[i] = vm.Instance(threadId)
+		// Start new thread-local instances of the VMs
+		for _, vm := range meta.vms {
+			vms = append(vms, vm.Instance(threadId))
 		}
+		// The fuzzing loop.
 		for file := range meta.testCh {
 			if meta.abort.Load() {
 				// Continue to drain the testch
 				continue
 			}
-			// Zero out the output files and reset offset
-			for _, f := range outputs {
-				_ = f.Truncate(0)
-				_, _ = f.Seek(0, 0)
-			}
 			var slowTest atomic.Bool
-			// Kick off the binaries, which runs the test on all the vms in parallel
 			var vmWg sync.WaitGroup
 			vmWg.Add(len(vms))
+			// Kick off the binaries, which runs the test on all the vms in parallel
 			for i, vm := range vms {
 				go func(evm evms.Evm, i int) {
 					defer vmWg.Done()
-					bufout := bufio.NewWriter(outputs[i])
-					res, err := evm.RunStateTest(file, bufout, false)
-					bufout.Flush()
+					outputs[i].Reset()
+					res, err := evm.RunStateTest(file, outputs[i], false)
 					commands[i] = res.Cmd
 					if err != nil {
 						log.Error("Error starting vm", "err", err, "command", res.Cmd)
@@ -604,33 +600,41 @@ func (meta *testMeta) startTracingTestExecutors(numThreads int) {
 				}(vm, i)
 			}
 			vmWg.Wait()
-			// All the tests are now executed, and we need to read and compare the outputs
-			var readers []io.Reader
-			// Flush file and set reset offset
-			for _, f := range outputs {
-				_ = f.Sync()
-				_, _ = f.Seek(0, 0)
-				readers = append(readers, f)
-			}
 			meta.numTests.Add(1)
+			// All the tests are now executed, and we need to read and compare the outputs
+			ok := true
+			ref := outputs[0].Sum()
+			for _, w := range outputs[1:] {
+				have := w.Sum()
+				ok = ok && bytes.Equal(have, ref)
+			}
+			if ok { // Output-hashes match, don't bother flushing to file and compare json.
+				if slowTest.Load() {
+					meta.slowCh <- file // flag as slow
+				} else {
+					meta.removeCh <- file // flag for removal
+				}
+				continue
+			}
+			// Output-hashes do not match. At this point, we flush the full output
+			// to file, and inspect line by line.
+			var readers []io.Reader
+			for _, w := range outputs {
+				w.FlushAndSeek()
+				readers = append(readers, w.f)
+			}
 			// Compare outputs
-			if eq, len := evms.CompareFiles(meta.vms, readers); !eq {
+			if eq, _ := evms.CompareFiles(meta.vms, readers); !eq {
 				meta.abort.Store(true)
-
 				out := new(strings.Builder)
 				fmt.Fprintf(out, "Consensus error\n")
 				fmt.Fprintf(out, "Testcase: %v\n", file)
-				for i, f := range outputs {
-					fmt.Fprintf(out, "- %v: %v\n", meta.vms[i].Name(), f.Name())
+				for i, w := range outputs {
+					fmt.Fprintf(out, "- %v: %v\n", meta.vms[i].Name(), w.f.Name())
 					fmt.Fprintf(out, "  - command: %v\n", commands[i])
 				}
 				fmt.Println(out)
 				meta.consensusCh <- file // flag as consensus-issue
-			} else if slowTest.Load() {
-				meta.slowCh <- file // flag as slow
-			} else {
-				meta.removeCh <- file // flag for removal
-				traceLengthSA.Add(len)
 			}
 		}
 	}
@@ -790,4 +794,54 @@ func ConvertToStateTest(name, fork string, alloc core.GenesisAlloc, gasLimit uin
 	}
 	fmt.Printf("Wrote file %v\n", fname)
 	return nil
+}
+
+// dualWriter is a io.Writer which writes to a hash, and also to a file, via a
+// 5-MB buffer. Ideally, the file-write never happens.
+// If the data is smaller than the internal buffer, and the hashes match up, the
+// writer can be Reset, and thus the file-write aborted.
+// This writer can thus be used to avoid both writing to (via buffer + discard)
+// and reading from (via hasher-check) disk.
+type dualWriter struct {
+	f   *os.File
+	out *bufio.Writer
+	sum hash.Hash
+}
+
+func newDualWriter(f *os.File) *dualWriter {
+	out := bufio.NewWriterSize(f, 5*1024*1024)
+	w := &dualWriter{
+		f:   f,
+		out: out,
+		sum: md5.New(),
+	}
+	w.Reset()
+	return w
+}
+
+func (w *dualWriter) Write(data []byte) (int, error) {
+	_, _ = w.out.Write(data)
+	return w.sum.Write(data)
+}
+
+func (w *dualWriter) Sum() []byte {
+	return w.sum.Sum(nil)
+}
+
+func (w *dualWriter) FlushAndSeek() {
+	w.out.Flush()
+	_ = w.f.Sync()
+	_, _ = w.f.Seek(0, 0)
+}
+
+func (w *dualWriter) Reset() {
+	_ = w.f.Truncate(0)
+	_, _ = w.f.Seek(0, 0)
+	w.out.Reset(w.f)
+	w.sum.Reset()
+}
+
+// Close closes the underlying file handle.
+func (w *dualWriter) Close() {
+	w.f.Close()
 }

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -165,9 +165,8 @@ func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 		if elem.Op == 0x0 {
 			continue
 		}
-		RemoveUnsupportedElems(&elem)
-		jsondata, _ := json.Marshal(elem)
-		if _, err := out.Write(append(jsondata, '\n')); err != nil {
+		outp := FastMarshal(&elem)
+		if _, err := out.Write(append(outp, '\n')); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing to out: %v\n", err)
 			return stateRoot
 		}

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -148,10 +148,8 @@ func (evm *ErigonVM) Copy(out io.Writer, input io.Reader) {
 		if elem.Op == 0x0 {
 			continue
 		}
-		RemoveUnsupportedElems(&elem)
-
-		jsondata, _ := json.Marshal(elem)
-		if _, err := out.Write(append(jsondata, '\n')); err != nil {
+		outp := FastMarshal(&elem)
+		if _, err := out.Write(append(outp, '\n')); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing to out: %v\n", err)
 			return
 		}

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -143,8 +143,8 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 			prev = current
 			return
 		}
-		jsondata, _ := json.Marshal(prev)
-		if _, err := out.Write(append(jsondata, '\n')); err != nil {
+		data := FastMarshal(prev)
+		if _, err := out.Write(append(data, '\n')); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing to out: %v\n", err)
 		}
 		if current == nil { // final flush
@@ -157,7 +157,6 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 			prev = current
 		}
 	}
-
 	for scanner.Scan() {
 		data := scanner.Bytes()
 		if len(data) > 0 && data[0] == '#' {
@@ -193,8 +192,6 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 		if elem.Op == 0x0 {
 			continue
 		}
-
-		RemoveUnsupportedElems(&elem)
 		yield(&elem)
 	}
 	yield(nil)

--- a/evms/marshalling.go
+++ b/evms/marshalling.go
@@ -1,0 +1,85 @@
+package evms
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
+)
+
+func JsonMarshal(log *logger.StructLog) []byte {
+	data, _ := json.Marshal(log)
+	return data
+}
+
+var FastMarshal = CustomMarshal
+
+// CustomMarshal writes a logger.Structlog element into a concise json format.
+// OBS! This output format will omit all stack element except the last 6 items.
+func CustomMarshal(log *logger.StructLog) []byte {
+	b := make([]byte, 0, 200)
+
+	// Depth : PC
+	b = append(b, `{"depth":`...)
+	b = strconv.AppendUint(b, uint64(log.Depth), 10)
+	b = append(b, []byte(`,"pc":`)...)
+	b = strconv.AppendUint(b, uint64(log.Pc), 10)
+
+	// Gas remaining
+	b = append(b, []byte(`,"gas":`)...)
+	b = strconv.AppendUint(b, uint64(log.Gas), 10)
+
+	// Op
+	b = append(b, []byte(`,"op":`)...)
+	b = strconv.AppendUint(b, uint64(log.Op), 10)
+	b = append(b, []byte(`,"opName":"`)...)
+	b = append(b, []byte(log.Op.String())...)
+	b = append(b, '"')
+
+	// Gascost of operation
+	if !ClearGascost {
+		b = append(b, []byte(`,"gasCost":`)...)
+		b = strconv.AppendUint(b, uint64(log.GasCost), 10)
+	}
+	// Memory size
+	if !ClearMemSize {
+		b = append(b, []byte(`,"memorySize":`)...)
+		b = strconv.AppendUint(b, uint64(log.MemorySize), 10)
+	}
+	// Refunds
+	if !ClearRefunds {
+		b = append(b, []byte(`,"refund":`)...)
+		b = strconv.AppendUint(b, uint64(log.RefundCounter), 10)
+	}
+	// Returndata
+	if !ClearReturndata {
+		b = append(b, []byte(`,"returnData":"0x`)...)
+		b = append(b, hexutil.Encode(log.ReturnData)...)
+		b = append(b, '"')
+	}
+	// Stack
+	// At most 6 stack items, top item last
+	b = append(b, []byte(`,"stack":[`)...)
+	start := len(log.Stack) - 6
+	if start < 0 {
+		start = 0
+	}
+	for i := start; i < len(log.Stack); i++ {
+		if i != start {
+			b = append(b, ',')
+		}
+		b = append(b, '"')
+		b = append(b, []byte(log.Stack[i].Hex())...)
+		b = append(b, '"')
+	}
+	b = append(b, ']')
+	// Error, if any
+	if log.Err != nil {
+		b = append(b, []byte(`,"error":"`)...)
+		b = append(b, []byte(log.Err.Error())...)
+		b = append(b, '"')
+	}
+	b = append(b, '}')
+	return b
+}

--- a/evms/marshalling_test.go
+++ b/evms/marshalling_test.go
@@ -1,0 +1,46 @@
+package evms
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
+	"github.com/holiman/uint256"
+)
+
+// Test that marshalling is valid json
+func TestMarshalling(t *testing.T) {
+	log := new(logger.StructLog)
+	for i := 0; i < 10; i++ {
+		el := uint256.NewInt(uint64(i))
+		log.Stack = append(log.Stack, *el)
+	}
+	if out := CustomMarshal(log); !json.Valid(out) {
+		t.Fatalf("invalid json: %v", string(out))
+	}
+}
+
+func BenchmarkMarshalling(b *testing.B) {
+
+	log := new(logger.StructLog)
+	for i := 0; i < 10; i++ {
+		el := uint256.NewInt(uint64(i))
+		log.Stack = append(log.Stack, *el)
+	}
+	var outp1 []byte
+	b.Run("json", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			outp1, _ = json.Marshal(log)
+		}
+	})
+	var outp2 []byte
+	b.Run("fast", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			outp2 = FastMarshal(log)
+		}
+	})
+	b.Log(string(outp1))
+	b.Log(string(outp2))
+}

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -89,7 +89,7 @@ func (evm *NethermindVM) RunStateTest(path string, out io.Writer, speedTest bool
 		cmd    = exec.Command(evm.path, "--trace", "-m", "--input", path)
 	)
 	if speedTest {
-		cmd = exec.Command(evm.path, "--trace", "-m", "--neverTrace", "--input", path)
+		cmd = exec.Command(evm.path, "-m", "--neverTrace", "--input", path)
 	}
 	if stderr, err = cmd.StderrPipe(); err != nil {
 		return &tracingResult{Cmd: cmd.String()}, err

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -159,10 +159,8 @@ func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot 
 		if elem.Op == 0x0 {
 			continue
 		}
-		RemoveUnsupportedElems(&elem)
-
-		jsondata, _ := json.Marshal(elem)
-		if _, err := out.Write(append(jsondata, '\n')); err != nil {
+		outp := FastMarshal(&elem)
+		if _, err := out.Write(append(outp, '\n')); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing to out: %v\n", err)
 			return stateRoot
 		}

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -147,9 +147,8 @@ func (evm *NimbusEVM) Copy(out io.Writer, input io.Reader) {
 		if elem.Op == 0x0 {
 			continue
 		}
-		RemoveUnsupportedElems(&elem)
-		jsondata, _ := json.Marshal(elem)
-		if _, err := out.Write(append(jsondata, '\n')); err != nil {
+		outp := FastMarshal(&elem)
+		if _, err := out.Write(append(outp, '\n')); err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing to out: %v\n", err)
 			return
 		}

--- a/evms/utils.go
+++ b/evms/utils.go
@@ -1,11 +1,5 @@
 package evms
 
-import (
-	"github.com/ethereum/go-ethereum/eth/tracers/logger"
-	"github.com/holiman/goevmlab/ops"
-	"github.com/holiman/uint256"
-)
-
 const (
 	// Nethermind does not support refundcounter
 	ClearRefunds = true
@@ -28,28 +22,3 @@ const (
 	// Besu sometimes reports GasCost of 0x7fffffffffffffff, along with ,"error":"Out of gas"
 	ClearGascost = true
 )
-
-// RemoveUnsupportedElems removes some elements that not all clients support.
-// Once the relevant json-fields have been added, we can remove things from this
-// method.
-func RemoveUnsupportedElems(elem *logger.StructLog) {
-	if elem.Stack == nil {
-		elem.Stack = make([]uint256.Int, 0)
-	}
-	elem.Memory = make([]byte, 0)
-
-	if ClearGascost {
-		elem.GasCost = 0
-	}
-	if ClearMemSize {
-		elem.MemorySize = 0
-	} else if ClearMemSizeOnExpand && ops.OpCode(elem.Op).ExpandsMem() {
-		elem.MemorySize = 0
-	}
-	if ClearRefunds {
-		elem.RefundCounter = 0
-	}
-	if ClearReturndata {
-		elem.ReturnData = nil
-	}
-}


### PR DESCRIPTION
Currently, all evms output is parsed, into `StructLog` items. Those are then lightly cleansed, and then marshalled into json again, and written to output files. 

In the next phase, those output files are then compared. This comparison is done line by line, and does not parse json, just compares the raw bytes. 

## Custom marshaller 

This PR changes the output / comparison phase. First of all, the 'standard' json marshaller is discarded, and instead a custom-made marshaller is used. This has three benefits

- It is much faster
- The custom marshaller removes the need for removing content from the log objects in a pre-step, since we can just omit emitting things we're not concerned about, 
- It only prints the top six stack items, making the output more condensed and less intensive to write and read. 


Example comparison-data before this PR: 
```json
{"pc":0,"op":0,"gas":"0x0","gasCost":"0x0","memSize":0,"stack":["0x0","0x1","0x2","0x3","0x4","0x5","0x6","0x7","0x8","0x9"],"depth":0,"refund":0,"opName":"STOP"}

```
Example comparison data with this PR: 
```json
 {"depth":0,"pc":0,"gas":0,"op":0,"opName":"STOP","stack":["0x4","0x5","0x6","0x7","0x8","0x9"]}
```
`162` vs `95` bytes on disk. This PR initially replaced `json` with an even more compact form, but reverted that, in order to make it interoperable with tools like `traceview`. 


## Avoid diskwrites

However, a more interesting optimization was added, where for the most part we don't even touch the disk. We use a `dualWriter`, and feeds the output above into it. 

The `dualWriter` does two things; writes into a `hash`, and writes to a buffered writer. The buffered writer has a capacity of 5Mb, if that gets full, it goes down to disk. After we're written everything, we compare the hashes for all evms. If the hashes match, we discard all buffered content, and don't read the files. Only if the hashes mismatch, do we actually flush the (last) 5MB of buffered data down to disk, and do the line-by-line comparison. 

For very large traces, there will be some disk-writes performed. 
For consensus-flaws, there will be both disk-writes and disk-readbacks. But most executions will never touch disk! 



