### PR TITLE
evms: nethermind - utilize multiple batcher instances

### DIFF
--- a/common/utils.go
+++ b/common/utils.go
@@ -526,12 +526,13 @@ type testMeta struct {
 // startTestFactories creates a number of go-routines that write tests to disk, and delivers
 // the paths on the testCh.
 func (meta *testMeta) startTestFactories(numFactories int, providerFn TestProviderFn) {
-	factories := int64(numFactories)
+	var factories atomic.Int64
+	factories.Add(numFactories)
 	meta.wg.Add(numFactories)
 	factory := func(threadId int) {
 		log.Info("Test factory thread started")
 		defer func() {
-			if f := atomic.AddInt64(&factories, -1); f == 0 {
+			if f := factories.Add(-1); f == 0 {
 				log.Info("Last test factory exiting\n")
 				close(meta.testCh)
 			}
@@ -674,19 +675,19 @@ func (meta *testMeta) startTracingTestExecutors(numThreads int) {
 }
 
 func (meta *testMeta) startNontracingTestExecutors(numThreads int) {
-	executors := int64(0)
+	var executors atomic.Int64
 	execute := func(threadId int) {
 		log.Info("Test executor routine started")
 		defer meta.wg.Done()
 		defer func() {
 			// clean-up tasks
-			if f := atomic.AddInt64(&executors, -1); f == 0 {
+			if f := executors.Add(-1); f == 0 {
 				close(meta.removeCh)
 				close(meta.slowCh)
 				log.Info("Last executor exiting")
 			}
 		}()
-		atomic.AddInt64(&executors, 1)
+		executors.Add(1)
 		log.Info("Fuzzing thread started", "id", threadId)
 
 		for file := range meta.testCh {

--- a/common/utils.go
+++ b/common/utils.go
@@ -527,7 +527,7 @@ type testMeta struct {
 // the paths on the testCh.
 func (meta *testMeta) startTestFactories(numFactories int, providerFn TestProviderFn) {
 	var factories atomic.Int64
-	factories.Add(numFactories)
+	factories.Add(int64(numFactories))
 	meta.wg.Add(numFactories)
 	factory := func(threadId int) {
 		log.Info("Test factory thread started")

--- a/evms/besubatcher.go
+++ b/evms/besubatcher.go
@@ -121,12 +121,6 @@ func (evm *BesuBatchVM) GetStateRoot(path string) (root, command string, err err
 	evm.mu.Lock()
 	defer evm.mu.Unlock()
 	_, _ = evm.stdin.Write([]byte(fmt.Sprintf("%v\n", path)))
-	sRoot := evm.copyUntilEnd(devNull{}, evm.stdout)
+	sRoot := evm.copyUntilEnd(io.Discard, evm.stdout)
 	return sRoot.StateRoot, evm.cmd.String(), nil
-}
-
-type devNull struct{}
-
-func (d devNull) Write(p []byte) (n int, err error) {
-	return len(p), nil
 }

--- a/evms/erigonbatcher.go
+++ b/evms/erigonbatcher.go
@@ -116,6 +116,6 @@ func (evm *ErigonBatchVM) GetStateRoot(path string) (root, command string, err e
 	evm.mu.Lock()
 	defer evm.mu.Unlock()
 	_, _ = evm.stdin.Write([]byte(fmt.Sprintf("%v\n", path)))
-	sRoot := evm.copyUntilEnd(devNull{}, evm.stdout)
+	sRoot := evm.copyUntilEnd(io.Discard, evm.stdout)
 	return sRoot.StateRoot, evm.cmd.String(), nil
 }

--- a/evms/gethbatcher.go
+++ b/evms/gethbatcher.go
@@ -116,6 +116,6 @@ func (evm *GethBatchVM) GetStateRoot(path string) (root, command string, err err
 	evm.mu.Lock()
 	defer evm.mu.Unlock()
 	_, _ = evm.stdin.Write([]byte(fmt.Sprintf("%v\n", path)))
-	sRoot := evm.copyUntilEnd(devNull{}, evm.stdout)
+	sRoot := evm.copyUntilEnd(io.Discard, evm.stdout)
 	return sRoot.StateRoot, evm.cmd.String(), nil
 }

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -46,8 +46,12 @@ func NewNethermindVM(path, name string) *NethermindVM {
 	}
 }
 
-func (evm *NethermindVM) Instance(int) Evm {
-	return evm
+func (evm *NethermindVM) Instance(threadId int) Evm {
+	return &NethermindVM{
+		path:  evm.path,
+		name:  fmt.Sprintf("%v-%d", evm.name, threadId),
+		stats: evm.stats,
+	}
 }
 
 func (evm *NethermindVM) Name() string {

--- a/evms/nethermindbatcher.go
+++ b/evms/nethermindbatcher.go
@@ -113,6 +113,6 @@ func (evm *NethermindBatchVM) GetStateRoot(path string) (root, command string, e
 	evm.mu.Lock()
 	defer evm.mu.Unlock()
 	_, _ = evm.stdin.Write([]byte(fmt.Sprintf("%v\n", path)))
-	sRoot := evm.copyUntilEnd(devNull{}, evm.stdout)
+	sRoot := evm.copyUntilEnd(io.Discard, evm.stdout)
 	return sRoot.StateRoot, evm.cmd.String(), nil
 }


### PR DESCRIPTION
Also make use of atomic types, and use io.Discard