### PR TITLE
Dockerfile for fuzzing 7 clients

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,109 @@
+#
+# The Mega Dockerfile
+#
+# This dockerfile is an attempt to bundle the following components into 
+# one big dockerfile:
+#
+# - [x] Goevmlab binary 'generic-fuzzer'
+# - [x] Go-ethereum binary 'evm'
+# - [ ] Erigon binary 'evm'
+# - [ ] EvmOne vm binary 'evmone'
+# - [x] Reth VM binary 'revme' 
+# - [ ] Besu
+# - [x] Nethermind
+# - [x] Nimbus-eth1
+#
+
+# ----------------------------------------------------------
+# These builds are performed with golang:latest, which is based on a Debian image
+# ----------------------------------------------------------
+
+#
+# GETH
+#
+
+# golang defaults to a debian flavour)
+FROM golang:latest as debian-builder 
+RUN git clone https://github.com/ethereum/go-ethereum --depth 1
+RUN cd go-ethereum && go run build/ci.go install -static ./cmd/evm && cd ..
+
+#
+# Go-evmlab
+#
+
+RUN git clone https://github.com/holiman/goevmlab --depth 1
+RUN cd goevmlab && go build ./cmd/generic-fuzzer && cd ..
+
+#
+# EVMONE 
+#
+
+#RUN apt-get update -q && apt-get install -qy --no-install-recommends \
+#    ca-certificates g++ cmake ninja-build libgmp-dev
+
+#RUN git clone https://github.com/ethereum/evmone.git --depth 1 --recurse-submodules
+#RUN cd evmone && \
+#    cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
+#RUN cd evmone && cmake --build build --parallel
+#RUN ls -laR /evmone
+
+#
+# NIMBUS-ETH1
+#
+
+
+RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules
+RUN apt update && apt install -y make
+RUN cd nimbus-eth1 && make -j4 update 
+RUN cd nimbus-eth1 && make -j8 evmstate 
+RUN cp nimbus-eth1/tools/evmstate/evmstate /evmstate
+
+
+#---------------------------------------------------------------
+# Another builder-image (cargo)
+#---------------------------------------------------------------
+
+#
+# RETH
+#
+
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS rust-builder
+RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN git clone https://github.com/bluealloy/revm.git --depth 1 
+RUN cd revm && cargo build --release --package revme
+
+
+#---------------------------------------------------------------
+# Another builder-image (dotnet)
+#---------------------------------------------------------------
+
+
+#
+# NETHERMIND
+#
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-builder
+RUN git clone https://github.com/NethermindEth/nethermind --depth 1 --recurse-submodules
+RUN cd nethermind/src/Nethermind/Nethermind.Test.Runner && dotnet publish --self-contained true -r linux-x64 -c Release
+RUN mkdir /out && mv nethermind/src/Nethermind/artifacts/bin/Nethermind.Test.Runner/release_linux-x64 /out/neth
+
+
+#
+# Main non-builder
+#
+
+FROM debian
+
+#nethtest requires libssl-dev
+RUN apt update && apt install -y libssl-dev
+
+COPY --from=debian-builder /go/go-ethereum/build/bin/evm /gethvm
+COPY --from=debian-builder /go/goevmlab/generic-fuzzer /generic-fuzzer
+COPY --from=debian-builder /evmstate /nimbvm
+#COPY --from=debian-builder /go/evmone/build/bin/evm /evmone
+COPY --from=rust-builder /revm/target/release/revme /revme
+COPY --from=dotnet-builder /out/neth /neth
+RUN ln -s /neth/nethtest /nethtest
+
+#ENTRYPOINT ["/bin/bash", "-l", "-c"]
+ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--fork=Cancun"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,10 +6,10 @@
 #
 # - [x] Goevmlab binary 'generic-fuzzer'
 # - [x] Go-ethereum binary 'evm'
-# - [ ] Erigon binary 'evm'
+# - [x] Erigon binary 'evm'
 # - [ ] EvmOne vm binary 'evmone'
 # - [x] Reth VM binary 'revme' 
-# - [ ] Besu
+# - [x] Besu
 # - [x] Nethermind
 # - [x] Nimbus-eth1
 #
@@ -35,19 +35,6 @@ RUN git clone https://github.com/holiman/goevmlab --depth 1
 RUN cd goevmlab && go build ./cmd/generic-fuzzer && cd ..
 
 #
-# EVMONE 
-#
-
-#RUN apt-get update -q && apt-get install -qy --no-install-recommends \
-#    ca-certificates g++ cmake ninja-build libgmp-dev
-
-#RUN git clone https://github.com/ethereum/evmone.git --depth 1 --recurse-submodules
-#RUN cd evmone && \
-#    cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
-#RUN cd evmone && cmake --build build --parallel
-#RUN ls -laR /evmone
-
-#
 # NIMBUS-ETH1
 #
 
@@ -61,6 +48,20 @@ RUN cp nimbus-eth1/tools/evmstate/evmstate /evmstate
 # Erigon
 RUN git clone https://github.com/ledgerwatch/erigon --depth 1
 RUN cd erigon && make evm && cp ./build/bin/evm /erigon_vm
+
+#
+# EVMONE 
+#
+
+RUN apt-get update -q && apt-get install -qy --no-install-recommends \
+    ca-certificates g++ cmake ninja-build libgmp-dev
+
+RUN git clone https://github.com/ethereum/evmone.git --depth 1 --recurse-submodules
+RUN cd evmone && \
+    cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
+RUN cd evmone && cmake --build build --parallel
+
+RUN cd evmone && ls -laR ./build/
 
 
 
@@ -127,11 +128,11 @@ COPY --from=debian-builder /go/go-ethereum/build/bin/evm /gethvm
 COPY --from=debian-builder /erigon_vm /erigon_vm
 COPY --from=debian-builder /go/goevmlab/generic-fuzzer /generic-fuzzer
 COPY --from=debian-builder /evmstate /nimbvm
-#COPY --from=debian-builder /go/evmone/build/bin/evm /evmone
+COPY --from=debian-builder /go/evmone/build/bin/evm /evmone
 COPY --from=rust-builder /revm/target/release/revme /revme
 COPY --from=dotnet-builder /out/neth /neth
 RUN ln -s /neth/nethtest /nethtest
 COPY --from=java-builder /out/evmtool /evmtool
 RUN ln -s /evmtool/bin/evm besu-vm
 
-ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--erigonbatch=/erigon_vm", "--besubatch=/besu-vm","--fork=Cancun"]
+ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--erigonbatch=/erigon_vm", "--besubatch=/besu-vm","--evmone=/evmone","--fork=Cancun"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,11 @@ RUN cd nimbus-eth1 && make -j4 update
 RUN cd nimbus-eth1 && make -j8 evmstate 
 RUN cp nimbus-eth1/tools/evmstate/evmstate /evmstate
 
+# Erigon
+RUN git clone https://github.com/ledgerwatch/erigon --depth 1
+RUN cd erigon && make evm && cp ./build/bin/evm /erigon_vm
+
+
 
 #---------------------------------------------------------------
 # Another builder-image (cargo)
@@ -98,6 +103,7 @@ FROM debian
 RUN apt update && apt install -y libssl-dev
 
 COPY --from=debian-builder /go/go-ethereum/build/bin/evm /gethvm
+COPY --from=debian-builder /erigon_vm /erigon_vm
 COPY --from=debian-builder /go/goevmlab/generic-fuzzer /generic-fuzzer
 COPY --from=debian-builder /evmstate /nimbvm
 #COPY --from=debian-builder /go/evmone/build/bin/evm /evmone
@@ -106,4 +112,4 @@ COPY --from=dotnet-builder /out/neth /neth
 RUN ln -s /neth/nethtest /nethtest
 
 #ENTRYPOINT ["/bin/bash", "-l", "-c"]
-ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--fork=Cancun"]
+ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--erigonbatch=/erigon_vm", "--fork=Cancun"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,14 +93,35 @@ RUN cd nethermind/src/Nethermind/Nethermind.Test.Runner && dotnet publish --self
 RUN mkdir /out && mv nethermind/src/Nethermind/artifacts/bin/Nethermind.Test.Runner/release_linux-x64 /out/neth
 
 
+
+#---------------------------------------------------------------
+# Another builder-image (ubuntu with java SDK)
+#---------------------------------------------------------------
+
+#
+# BESU 
+#
+
+FROM ubuntu:23.10 as java-builder
+
+RUN apt update && apt install -y --no-install-recommends git ca-certificates 
+RUN git clone https://github.com/hyperledger/besu.git --depth 1 #--recurse-submodules
+RUN apt install --no-install-recommends -q -y git openjdk-17-jre-headless=17* libjemalloc-dev=5.* 
+RUN cd besu && ./gradlew --parallel ethereum:evmtool:installDist
+RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
+
 #
 # Main non-builder
 #
 
 FROM debian
 
+RUN apt update
 #nethtest requires libssl-dev
-RUN apt update && apt install -y libssl-dev
+RUN apt install -y libssl-dev
+# besu requires openjdk-17-jre
+RUN apt install -y --no-install-recommends  openjdk-17-jre 
+
 
 COPY --from=debian-builder /go/go-ethereum/build/bin/evm /gethvm
 COPY --from=debian-builder /erigon_vm /erigon_vm
@@ -110,6 +131,7 @@ COPY --from=debian-builder /evmstate /nimbvm
 COPY --from=rust-builder /revm/target/release/revme /revme
 COPY --from=dotnet-builder /out/neth /neth
 RUN ln -s /neth/nethtest /nethtest
+COPY --from=java-builder /out/evmtool /evmtool
+RUN ln -s /evmtool/bin/evm besu-vm
 
-#ENTRYPOINT ["/bin/bash", "-l", "-c"]
-ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--erigonbatch=/erigon_vm", "--fork=Cancun"]
+ENTRYPOINT ["/generic-fuzzer","--gethbatch=/gethvm","--nethbatch=/nethtest","--nimbus=/nimbvm","--revme=/revme", "--erigonbatch=/erigon_vm", "--besubatch=/besu-vm","--fork=Cancun"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,14 @@ FROM golang:latest as golang-builder
 #
 
 RUN git clone https://github.com/holiman/goevmlab --depth 1
-RUN cd goevmlab && go build ./cmd/...
+RUN cd goevmlab && \
+  go build ./cmd/generic-fuzzer && \
+  go build ./cmd/checkslow && \
+  go build ./cmd/minimizer && \
+  go build ./cmd/repro && \
+  go build ./cmd/runtest && \
+  go build ./cmd/tracediff && \
+  go build ./cmd/traceview
 
 #
 # GETH
@@ -49,6 +56,10 @@ RUN cd nimbus-eth1 && make -j8 update
 RUN cd nimbus-eth1 && make -j8 evmstate 
 RUN cp nimbus-eth1/tools/evmstate/evmstate /evmstate
 
+RUN echo "please" >> /build.sequential
+
+RUN ls -la /go/goevmlab/tracediff
+
 #---------------------------------------------------------------
 # debian-builder
 #---------------------------------------------------------------
@@ -57,17 +68,19 @@ RUN cp nimbus-eth1/tools/evmstate/evmstate /evmstate
 # EVMONE 
 #
 #
-# evmone requires g++ v12 or 13, which is _not_ available in debian bookworm (the golang image)
-# but it works with debian:latest (at the time of writing this) 
+# evmone requires g++ v13, which is _not_ available in debian bookworm (the golang image)
+# but it works with debian:testing (at the time of writing this) 
 
-FROM debian:latest as debian-builder
+FROM debian:testing as debian-builder
 RUN apt-get update -q && apt-get install -qy --no-install-recommends git make \
     ca-certificates g++ cmake ninja-build libgmp-dev
+COPY --from=golang-builder /build.sequential /build.sequential
+
 RUN git clone https://github.com/ethereum/evmone.git --depth 1 --recurse-submodules
 RUN cd evmone && cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
 RUN cd evmone && cmake --build build --parallel
-RUN cd evmone && ls -laR ./build/
-
+RUN cp /evmone/build/bin/evmone-statetest /evmone-statetest
+RUN cp /evmone/build/lib/libevmone.so.0.12 /libevmone.so.0.12
 #---------------------------------------------------------------
 # rust-builder
 #---------------------------------------------------------------
@@ -78,6 +91,7 @@ RUN cd evmone && ls -laR ./build/
 
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS rust-builder
 RUN apt-get update -q && apt-get install -qy --no-install-recommends libclang-dev pkg-config
+COPY --from=debian-builder /build.sequential /build.sequential
 RUN git clone https://github.com/bluealloy/revm.git --depth 1 
 RUN cd revm && cargo build --release --package revme
 
@@ -93,6 +107,8 @@ RUN cd revm && cargo build --release --package revme
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-jammy AS dotnet-builder
 RUN git clone https://github.com/NethermindEth/nethermind --depth 1 --recurse-submodules
+COPY --from=rust-builder /build.sequential /build.sequential
+
 RUN cd nethermind/src/Nethermind/Nethermind.Test.Runner && dotnet publish --self-contained true -r linux-x64 -c Release
 RUN mkdir /out && mv nethermind/src/Nethermind/artifacts/bin/Nethermind.Test.Runner/release_linux-x64 /out/neth
 
@@ -109,6 +125,7 @@ FROM ubuntu:23.10 as java-builder
 RUN apt-get update -q && apt-get install -qy --no-install-recommends git ca-certificates 
 RUN git clone https://github.com/hyperledger/besu.git --depth 1 #--recurse-submodules
 RUN apt-get install -qy --no-install-recommends git openjdk-17-jre-headless=17* libjemalloc-dev=5.* 
+COPY --from=dotnet-builder /build.sequential /build.sequential
 RUN cd besu && ./gradlew --parallel ethereum:evmtool:installDist
 RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
 
@@ -116,14 +133,13 @@ RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
 # Main non-builder
 #
 
-FROM debian
+FROM debian:testing
 
 RUN apt-get update -q
-#nethtest requires libssl-dev
+# nethtest requires libssl-dev
 RUN apt-get install -qy --no-install-recommends libssl-dev
 # besu requires openjdk-17-jre
 RUN apt-get install -qy --no-install-recommends  openjdk-17-jre 
-
 
 # Go-evmlab targets
 COPY --from=golang-builder /go/goevmlab/generic-fuzzer /
@@ -138,7 +154,8 @@ COPY --from=golang-builder /go/go-ethereum/build/bin/evm /gethvm
 COPY --from=golang-builder /erigon_vm /erigon_vm
 COPY --from=golang-builder /evmstate /nimbvm
 
-COPY --from=debian-builder /go/evmone/build/bin/evmone /evmone
+COPY --from=debian-builder /evmone-statetest /evmone
+COPY --from=debian-builder /libevmone.so.0.12 /lib/libevmone.so.0.12
 
 COPY --from=rust-builder /revm/target/release/revme /revme
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,66 +7,69 @@
 # - [x] Goevmlab binary 'generic-fuzzer'
 # - [x] Go-ethereum binary 'evm'
 # - [x] Erigon binary 'evm'
-# - [ ] EvmOne vm binary 'evmone'
+# - [x] EvmOne vm binary 'evmone'
 # - [x] Reth VM binary 'revme' 
 # - [x] Besu
 # - [x] Nethermind
 # - [x] Nimbus-eth1
 #
 
-# ----------------------------------------------------------
-# These builds are performed with golang:latest, which is based on a Debian image
-# ----------------------------------------------------------
-
-#
-# GETH
-#
-
-# golang defaults to a debian flavour)
-FROM golang:latest as debian-builder 
-RUN git clone https://github.com/ethereum/go-ethereum --depth 1
-RUN cd go-ethereum && go run build/ci.go install -static ./cmd/evm && cd ..
+#---------------------------------------------------------------
+# golang-builder (debian-based)
+#---------------------------------------------------------------
+FROM golang:latest as golang-builder 
 
 #
 # Go-evmlab
 #
 
 RUN git clone https://github.com/holiman/goevmlab --depth 1
-RUN cd goevmlab && go build ./cmd/generic-fuzzer && cd ..
+RUN cd goevmlab && go build ./cmd/...
+
+#
+# GETH
+#
+
+RUN git clone https://github.com/ethereum/go-ethereum --depth 1
+RUN cd go-ethereum && go run build/ci.go install -static ./cmd/evm
+
+#
+# Erigon
+#
+RUN git clone https://github.com/ledgerwatch/erigon --depth 1
+RUN cd erigon && make evm && cp ./build/bin/evm /erigon_vm
 
 #
 # NIMBUS-ETH1
 #
 
-
 RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules
-RUN apt update && apt install -y make
-RUN cd nimbus-eth1 && make -j4 update 
+RUN apt-get update -q && apt-get install -qy --no-install-recommends make
+RUN cd nimbus-eth1 && make -j8 update 
 RUN cd nimbus-eth1 && make -j8 evmstate 
 RUN cp nimbus-eth1/tools/evmstate/evmstate /evmstate
 
-# Erigon
-RUN git clone https://github.com/ledgerwatch/erigon --depth 1
-RUN cd erigon && make evm && cp ./build/bin/evm /erigon_vm
+#---------------------------------------------------------------
+# debian-builder
+#---------------------------------------------------------------
 
 #
 # EVMONE 
 #
+#
+# evmone requires g++ v12 or 13, which is _not_ available in debian bookworm (the golang image)
+# but it works with debian:latest (at the time of writing this) 
 
-RUN apt-get update -q && apt-get install -qy --no-install-recommends \
+FROM debian:latest as debian-builder
+RUN apt-get update -q && apt-get install -qy --no-install-recommends git make \
     ca-certificates g++ cmake ninja-build libgmp-dev
-
 RUN git clone https://github.com/ethereum/evmone.git --depth 1 --recurse-submodules
-RUN cd evmone && \
-    cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
+RUN cd evmone && cmake -S . -B build -DEVMONE_TESTING=ON -DEVMONE_PRECOMPILES_SILKPRE=1
 RUN cd evmone && cmake --build build --parallel
-
 RUN cd evmone && ls -laR ./build/
 
-
-
 #---------------------------------------------------------------
-# Another builder-image (cargo)
+# rust-builder
 #---------------------------------------------------------------
 
 #
@@ -74,13 +77,13 @@ RUN cd evmone && ls -laR ./build/
 #
 
 FROM lukemathwalker/cargo-chef:latest-rust-1 AS rust-builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
+RUN apt-get update -q && apt-get install -qy --no-install-recommends libclang-dev pkg-config
 RUN git clone https://github.com/bluealloy/revm.git --depth 1 
 RUN cd revm && cargo build --release --package revme
 
 
 #---------------------------------------------------------------
-# Another builder-image (dotnet)
+# dotnet-builder
 #---------------------------------------------------------------
 
 
@@ -93,10 +96,8 @@ RUN git clone https://github.com/NethermindEth/nethermind --depth 1 --recurse-su
 RUN cd nethermind/src/Nethermind/Nethermind.Test.Runner && dotnet publish --self-contained true -r linux-x64 -c Release
 RUN mkdir /out && mv nethermind/src/Nethermind/artifacts/bin/Nethermind.Test.Runner/release_linux-x64 /out/neth
 
-
-
 #---------------------------------------------------------------
-# Another builder-image (ubuntu with java SDK)
+# java-builder
 #---------------------------------------------------------------
 
 #
@@ -105,9 +106,9 @@ RUN mkdir /out && mv nethermind/src/Nethermind/artifacts/bin/Nethermind.Test.Run
 
 FROM ubuntu:23.10 as java-builder
 
-RUN apt update && apt install -y --no-install-recommends git ca-certificates 
+RUN apt-get update -q && apt-get install -qy --no-install-recommends git ca-certificates 
 RUN git clone https://github.com/hyperledger/besu.git --depth 1 #--recurse-submodules
-RUN apt install --no-install-recommends -q -y git openjdk-17-jre-headless=17* libjemalloc-dev=5.* 
+RUN apt-get install -qy --no-install-recommends git openjdk-17-jre-headless=17* libjemalloc-dev=5.* 
 RUN cd besu && ./gradlew --parallel ethereum:evmtool:installDist
 RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
 
@@ -117,21 +118,33 @@ RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
 
 FROM debian
 
-RUN apt update
+RUN apt-get update -q
 #nethtest requires libssl-dev
-RUN apt install -y libssl-dev
+RUN apt-get install -qy --no-install-recommends libssl-dev
 # besu requires openjdk-17-jre
-RUN apt install -y --no-install-recommends  openjdk-17-jre 
+RUN apt-get install -qy --no-install-recommends  openjdk-17-jre 
 
 
-COPY --from=debian-builder /go/go-ethereum/build/bin/evm /gethvm
-COPY --from=debian-builder /erigon_vm /erigon_vm
-COPY --from=debian-builder /go/goevmlab/generic-fuzzer /generic-fuzzer
-COPY --from=debian-builder /evmstate /nimbvm
-COPY --from=debian-builder /go/evmone/build/bin/evm /evmone
+# Go-evmlab targets
+COPY --from=golang-builder /go/goevmlab/generic-fuzzer /
+COPY --from=golang-builder /go/goevmlab/checkslow  /
+COPY --from=golang-builder /go/goevmlab/minimizer /
+COPY --from=golang-builder /go/goevmlab/repro /
+COPY --from=golang-builder /go/goevmlab/runtest /
+COPY --from=golang-builder /go/goevmlab/tracediff /
+COPY --from=golang-builder /go/goevmlab/traceview /
+
+COPY --from=golang-builder /go/go-ethereum/build/bin/evm /gethvm
+COPY --from=golang-builder /erigon_vm /erigon_vm
+COPY --from=golang-builder /evmstate /nimbvm
+
+COPY --from=debian-builder /go/evmone/build/bin/evmone /evmone
+
 COPY --from=rust-builder /revm/target/release/revme /revme
+
 COPY --from=dotnet-builder /out/neth /neth
 RUN ln -s /neth/nethtest /nethtest
+
 COPY --from=java-builder /out/evmtool /evmtool
 RUN ln -s /evmtool/bin/evm besu-vm
 


### PR DESCRIPTION
 This is an attempt to bundle the fuzzing-components into one big dockerfile:

 - [x] Goevmlab binary 'generic-fuzzer'
 - [x] Go-ethereum binary `evm`
 - [x] Erigon binary `evm`
 - [x] EvmOne vm binary `evmone`
 - [x] Reth VM binary `revme` 
 - [x] Besu
 - [x] Nethermind `nethtest`
 - [x] Nimbus-eth1 `evmstate`

Can be run via 
```
docker run -it holiman/omnifuzz
```