### PR TITLE
Faster execution of fuzzing-pipeline

### DIFF
--- a/cmd/runtest/main.go
+++ b/cmd/runtest/main.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +24,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/holiman/goevmlab/common"
 	"github.com/urfave/cli/v2"
+	"io"
 	"sync/atomic"
 )
 
@@ -59,11 +59,11 @@ func startFuzzer(c *cli.Context) error {
 		return err
 	}
 	var nextFile atomic.Int64
-	return common.ExecuteFuzzer(c, func(_, _ int) (string, error) {
+	return common.ExecuteFuzzer(c, true, func(_, _ int) (string, error) {
 		index := int(nextFile.Add(1)) - 1
 		if index < len(files) {
 			return files[index], nil
 		}
-		return "", errors.New("done")
+		return "", io.EOF
 	}, false)
 }

--- a/cmd/testvm/main.go
+++ b/cmd/testvm/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func main() {
+	time.Sleep(500 * time.Millisecond)
+	out := `{"pc":0,"op":96,"gas":"0x4757","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":2,"op":96,"gas":"0x4754","gasCost":"0x3","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":13,"op":96,"gas":"0xf2","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":15,"op":84,"gas":"0xef","gasCost":"0x834","memSize":0,"stack":["0x3"],"depth":1,"refund":0,"opName":"SLOAD","error":"out of gas"}
+{"output":"","gasUsed":"0x4757","error":"out of gas"}
+{"stateRoot": "0x75dc56643cc707a2e6c9a4cf7e28061e9598bd02ecac22c406365c058088d59b"}`
+
+	out2 := `{"pc":0,"op":96,"gas":"0x4757","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":2,"op":96,"gas":"0x4754","gasCost":"0x3","memSize":0,"stack":["0x0"],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":13,"op":96,"gas":"0xf2","gasCost":"0x3","memSize":0,"stack":[],"depth":1,"refund":0,"opName":"PUSH1"}
+{"pc":15,"op":84,"gas":"0xef","gasCost":"0x834","memSize":0,"stack":["0x1"],"depth":1,"refund":0,"opName":"SLOAD","error":"out of gas"}
+{"output":"","gasUsed":"0x4757","error":"out of gas"}
+{"stateRoot": "0xaaaaaaaaaaabbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccccccccc"}`
+	if true {
+		fmt.Fprint(os.Stderr, out2)
+		fmt.Fprint(os.Stdout, out2)
+	} else {
+		fmt.Fprint(os.Stderr, out)
+		fmt.Fprint(os.Stdout, out)
+	}
+}

--- a/cmd/testvm/readme.md
+++ b/cmd/testvm/readme.md
@@ -1,0 +1,13 @@
+### TestVM
+
+This is a small utility to aid testing. It can be used to simulate the execution of clients. 
+It behaves somewhat like a geth-client. 
+
+E.g. 
+```
+generic-fuzzer --geth ./testvm-01 --geth ./testvm-02 --geth ./testvm-03
+```
+Where the three testvm's are compiled with different speeds (so one takes 500ms and another 200ms), 
+or where one of them triggers a consensus issue. 
+
+The idea is to use this to help test tools like `generic-fuzzer`, `runtest` or `minimizer`. 

--- a/common/utils.go
+++ b/common/utils.go
@@ -630,11 +630,11 @@ func (meta *testMeta) startTracingTestExecutors(numThreads int) {
 					defer vmWg.Done()
 					outputs[i].Reset()
 					res, err := evm.RunStateTest(file, outputs[i], false)
-					commands[i] = res.Cmd
 					if err != nil {
-						log.Error("Error starting vm", "err", err, "command", res.Cmd)
+						log.Error("Error starting vm", "err", err, "evm", evm.Name())
 						return
 					}
+					commands[i] = res.Cmd
 					if res.Slow {
 						// Flag test as slow
 						log.Warn("Slow test found", "evm", evm.Name(), "time", res.ExecTime, "cmd", res.Cmd, "file", file)

--- a/common/utils.go
+++ b/common/utils.go
@@ -377,8 +377,8 @@ func ExecuteFuzzer(c *cli.Context, allClients bool, providerFn TestProviderFn, c
 	}
 	log.Info("Fuzzing started", "threads", numThreads)
 	meta := &testMeta{
-		testCh:              make(chan string, 10), // channel where we'll deliver tests
-		consensusCh:         make(chan string, 10), // channel for signalling consensus errors
+		testCh:              make(chan string, 4), // channel where we'll deliver tests
+		consensusCh:         make(chan string, 4), // channel for signalling consensus errors
 		vms:                 vms,
 		deleteFilesWhenDone: cleanupFiles,
 	}
@@ -500,7 +500,6 @@ func Copy(src, dst string) error {
 
 type testMeta struct {
 	abort       atomic.Bool
-	errCh       chan error
 	testCh      chan string
 	consensusCh chan string
 	wg          sync.WaitGroup
@@ -627,8 +626,8 @@ func (meta *testMeta) handleConsensusFlaw(testfile string) {
 		}
 		fmt.Fprintf(os.Stdout, "- %v: %v\n", evm.Name(), filename)
 		fmt.Fprintf(os.Stdout, "  - command: %v\n", res.Cmd)
-		out.Sync()
-		out.Seek(0, 0)
+		_ = out.Sync()
+		_, _ = out.Seek(0, 0)
 		readers = append(readers, out)
 	}
 	// Compare outputs (and show diff)

--- a/common/utils.go
+++ b/common/utils.go
@@ -371,7 +371,6 @@ func GenerateAndExecute(c *cli.Context, generatorFn GeneratorFn, name string) er
 }
 
 func ExecuteFuzzer(c *cli.Context, providerFn TestProviderFn, cleanupFiles bool) error {
-
 	var (
 		vms        = initVMs(c)
 		numThreads = c.Int(ThreadFlag.Name)
@@ -567,7 +566,7 @@ func (meta *testMeta) vmLoop(evm evms.Evm, taskCh, resultCh chan *task) {
 		res, err := evm.RunStateTest(t.file, hasher, t.skipTrace)
 		if err != nil {
 			log.Error("Error starting vm", "err", err, "evm", evm.Name())
-			t.err = fmt.Errorf("error starting vm %v: %w", evm.Name, err)
+			t.err = fmt.Errorf("error starting vm %v: %w", evm.Name(), err)
 			// Send back
 			resultCh <- t
 			continue

--- a/evms/besu.go
+++ b/evms/besu.go
@@ -180,5 +180,5 @@ func (evm *BesuVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *BesuVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return evm.stats.Stats()
 }

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -172,5 +172,5 @@ func (evm *ErigonVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *ErigonVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return evm.stats.Stats()
 }

--- a/evms/evmone.go
+++ b/evms/evmone.go
@@ -165,5 +165,5 @@ func (evm *EvmoneVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *EvmoneVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return evm.stats.Stats()
 }

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -203,5 +203,7 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *GethEVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond),
+		"longest", evm.stats.longestTracingTime,
+		"count", evm.stats.numExecs.Load()}
 }

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -203,7 +203,5 @@ func (evm *GethEVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot {
 }
 
 func (evm *GethEVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond),
-		"longest", evm.stats.longestTracingTime,
-		"count", evm.stats.numExecs.Load()}
+	return evm.stats.Stats()
 }

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -177,5 +177,5 @@ func (evm *NethermindVM) copyUntilEnd(out io.Writer, input io.Reader) stateRoot 
 }
 
 func (evm *NethermindVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return evm.stats.Stats()
 }

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -185,5 +185,5 @@ func (evm *NimbusEVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *NimbusEVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return evm.stats.Stats()
 }

--- a/evms/revm.go
+++ b/evms/revm.go
@@ -162,5 +162,5 @@ func (evm *RethVM) Copy(out io.Writer, input io.Reader) {
 }
 
 func (evm *RethVM) Stats() []any {
-	return []interface{}{"execSpeed", time.Duration(evm.stats.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond), "longest", evm.stats.longestTracingTime}
+	return evm.stats.Stats()
 }

--- a/evms/vmstats.go
+++ b/evms/vmstats.go
@@ -30,6 +30,14 @@ func (stat *VmStat) TraceDone(start time.Time) (time.Duration, bool) {
 	return duration, false
 }
 
+func (stat *VmStat) Stats() []any {
+	return []interface{}{
+		"execSpeed", time.Duration(stat.tracingSpeedWMA.Avg()).Round(100 * time.Microsecond),
+		"longest", stat.longestTracingTime,
+		"count", stat.numExecs.Load(),
+	}
+}
+
 type tracingResult struct {
 	Slow     bool
 	ExecTime time.Duration


### PR DESCRIPTION
This PR implements https://github.com/holiman/goevmlab/issues/120. This creates a huge speed-boost in the case where many clients are used. 

Previously, the general flow of execution was

- Generate a test
- Spin up `n` clients to execute it, 
- Wait for all to complete
- Compare the outputs
- Repeat

That is, every test is executed by `n` clients, and the slowest one sets the pace. With this PR, we instead do 

- Generate a test
- Wait until we have two clients ready, task them to execute it, 
- Whenever a client is done, handle it's output, put into ready-queue
- Repeat

That is, every test is executed by `2` clients, the first two clients that are available. Whenever a client becomes available, it is tasked with a new test shortly. 

So instead of the slowest client setting the pace, each client can execute in their own pace, and they get a corresponding workload. Faster clients get more test coverage. 
