### PR TITLE
evms: ensure to drain proc output-pipe before invoking wait. 

### DIFF
--- a/evms/besu.go
+++ b/evms/besu.go
@@ -74,6 +74,7 @@ func (evm *BesuVM) RunStateTest(path string, out io.Writer, speedTest bool) (*tr
 	}
 	// copy everything to the given writer
 	evm.Copy(out, stdout)
+	_, _ = io.ReadAll(stdout)
 	err = cmd.Wait()
 	// release resources
 	duration, slow := evm.stats.TraceDone(t0)

--- a/evms/eels.go
+++ b/evms/eels.go
@@ -104,6 +104,7 @@ func (evm *EelsEVM) RunStateTest(path string, out io.Writer, speedTest bool) (*t
 	}
 	// copy everything to the given writer
 	evm.Copy(out, stderr)
+	_, _ = io.ReadAll(stderr)
 	err = cmd.Wait()
 	// release resources
 	duration, slow := evm.stats.TraceDone(t0)

--- a/evms/erigon.go
+++ b/evms/erigon.go
@@ -100,6 +100,7 @@ func (evm *ErigonVM) RunStateTest(path string, out io.Writer, speedTest bool) (*
 	}
 	// copy everything to the given writer
 	evm.Copy(out, stderr)
+	_, _ = io.ReadAll(stderr)
 	err = cmd.Wait()
 	// release resources
 	duration, slow := evm.stats.TraceDone(t0)

--- a/evms/evmone.go
+++ b/evms/evmone.go
@@ -100,6 +100,7 @@ func (evm *EvmoneVM) RunStateTest(path string, out io.Writer, speedTest bool) (*
 	}
 
 	evm.Copy(out, stderr)
+	_, _ = io.ReadAll(stderr)
 	err = cmd.Wait()
 	duration, slow := evm.stats.TraceDone(t0)
 

--- a/evms/geth.go
+++ b/evms/geth.go
@@ -101,6 +101,7 @@ func (evm *GethEVM) RunStateTest(path string, out io.Writer, speedTest bool) (*t
 	}
 	// copy everything to the given writer
 	evm.Copy(out, stderr)
+	_, _ = io.ReadAll(stderr)
 	err = cmd.Wait()
 	// release resources
 	duration, slow := evm.stats.TraceDone(t0)

--- a/evms/nethermind.go
+++ b/evms/nethermind.go
@@ -109,6 +109,7 @@ func (evm *NethermindVM) RunStateTest(path string, out io.Writer, speedTest bool
 	// copy everything to the given writer
 	evm.copyUntilEnd(out, procOut, speedTest)
 	// release resources, handle error but ignore non-zero exit codes
+	_, _ = io.ReadAll(procOut)
 	_ = cmd.Wait()
 	duration, slow := evm.stats.TraceDone(t0)
 	return &tracingResult{

--- a/evms/nimbus.go
+++ b/evms/nimbus.go
@@ -102,6 +102,7 @@ func (evm *NimbusEVM) RunStateTest(path string, out io.Writer, speedTest bool) (
 	// copy everything to the given writer
 	evm.Copy(out, stderr)
 	// Nimbus returns a non-zero exit code for tests that do not pass. We just ignore that.
+	_, _ = io.ReadAll(stderr)
 	_ = cmd.Wait()
 	// release resources
 	duration, slow := evm.stats.TraceDone(t0)

--- a/evms/revm.go
+++ b/evms/revm.go
@@ -103,6 +103,8 @@ func (evm *RethVM) RunStateTest(path string, out io.Writer, speedTest bool) (*tr
 	}
 
 	evm.Copy(out, stderr)
+	// drain stderr
+	_, _ = io.ReadAll(stderr)
 	err = cmd.Wait()
 	duration, slow := evm.stats.TraceDone(t0)
 


### PR DESCRIPTION
This fixes a 'hang' in revme due to json parser not fully consuming all output. 
This seems to be the root cause behind https://github.com/holiman/goevmlab/issues/160 , where certain outputs would cause the runner not to finihs. 
Example testcase that hangs (e.g. tested via `runtest`) on revme without this PR: 
```
{
  "00186451-mixed-10": {
    "env": {
      "currentCoinbase": "b94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "currentDifficulty": "0x200000",
      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000200000",
      "currentGasLimit": "0x26e1f476fe1e22",
      "currentNumber": "0x1",
      "currentTimestamp": "0x3e8",
      "previousHash": "0x044852b2a670ade5407e78fb2863c51de9fcb96542a07186fe3aeda6bb8a116d",
      "currentBaseFee": "0x10"
    },
    "pre": {
      "0x00000000000000000000000000000000000000f1": {
        "code": "0x6025606860b9605060bb60ac60a461789946fd153965967a90039e07457433625503104310615300803e1b38951379851a9a3c738c087d7d9d7d87174336a38544827f6c77807c6713414164423b201834903b7af03837741666139b6995413b0a78583913fe013e2033796a60345344427e0b9f3c5859036a5a3b005b8ff4038c4250536f1b8d7e415a1493606563641136734139642048996d3c414252418269433c7d17343b3b8372526d7fa1894252448f0695a05916706746318c7001853d6b4106394551651669089b44156a486cf44043f0335a6a7c52f5469534427387657d737c09637d12f010f25a6089443706631947103b901c8206340210417514533e8c181d716d6554748f3c74683f78593e51508b8d666e617557773647621579099d11817d553a41325a5a99893637fa3478818857886a65889a1d67081572008f9869973f3b57f31b14029e7908188e67754715177e314888327d533e4404189ef3a08d531d1c451362998b180b5b013054598134761b799b12507b84836662180b567781096f72891598836000627e199b1d5b40613674558789709c856c66665a437659776a9d8b7f8a3670355250179c0000644759f41c5a9f00419169865431200933a03893688fa044a319948c09a2668015816767880a8f3b75a0873014746f16678d4418317709640902927e11f0756d04893c02569aa220519a466717137a5a7965967d1364630b4460358098930254840a1b6a94441c0b326d0675160a5279727445105b59836e303341056b6333435b187645456e8a3c85536989673e8e3433426f1a6d7f98024545408b6d34131a953f998c3591a2ff47668d74587f9b431312f2723b7e43696a051a3631fff03576178542f28c167e1c204191397d0108420835825b9b625bf11131732088203f8fa3606f1d6914311c3c53fe824067558231703065468e333c6918616c8e8268575b6217457703395a3e193f80840179060183791967738383208f0962097814901c755a19866b869983389647781d6c9f3a71518a9b3b1311008a7c465a9206fd7e7f797a02387b9151616c171236900408643e3838070a66488d7a8b3d7f1af26b1c1d601c38f30a025a6111f316424469814196753f3e7662876b1141419c7d420a7274390567180b1b70a161ff329432095b38401c7566947259426781300a37396384746f206e06711a1c3b1797698e66478e3a053b376065404408ff8104121c35096c3a45923b6882646098411b8d378e83503a5183055b1b8a416b663f7a5a167a78305b077d99186e47128483a381915587fd6855663c96486a44103bf5653d30360498826848690439a16c1183058aa013308e1b97648e86883d1d4614141884fd20638d857b621a598567149a6c8d037530163834827d046806163bf269f057858b1b3383",
        "storage": {
          "0x0000000000000000000000000000000000000000000000000000000000000000": "0x000000000000000000000000000000000000000000000000000000000000000f",
          "0x0000000000000000000000000000000000000000000000000000000000000003": "0x0000000000000000000000000000000000000000000000000000000000000010"
        },
        "balance": "0x0",
        "nonce": "0x0"
      },
      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
        "code": "0x",
        "storage": {},
        "balance": "0xffffffffff",
        "nonce": "0x0"
      }
    },
    "transaction": {
      "gasPrice": "0x10",
      "nonce": "0x0",
      "to": "0x00000000000000000000000000000000000000f1",
      "data": [
        "0x8b5c72c68d612bf44adb05937bbc2b8fb69d8501595522d0a6083e800517bdddbfa68cdd885de9a9b5a6bbc2372374de0e716ce95a1960650c5c5bff628202ae38579b8ac3934c"
      ],
      "gasLimit": [
        "0x7a1200"
      ],
      "value": [
        "0x6acdeb"
      ],
      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
    },
    "out": "0x",
    "post": {
      "Merge": [
        {
          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "logs": "0x0000000000000000000000000000000000000000000000000000000000000000",
          "indexes": {
            "data": 0,
            "gas": 0,
            "value": 0
          }
        }
      ]
    }
  }
}

```