### PR TITLE
Smaller docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -180,7 +180,7 @@ COPY --from=golang-builder /erigon_vm /erigon_vm
 COPY --from=golang-builder /libsilkworm_capi.so /lib/libsilkworm_capi.so
 ENV ERIG_BIN=/erigon_vm
 
-#COPY --from=golang-builder /evmstate /nimbvm
+COPY --from=golang-builder /evmstate /nimbvm
 ENV NIMB_BIN=/nimbvm
 
 COPY --from=debian-builder /evmone-statetest /evmone

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,9 +60,6 @@ RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-s
  make -j8 evmstate && cp ./tools/evmstate/evmstate /evmstate
 
 
-
-
-
 #---------------------------------------------------------------
 # debian-builder
 #---------------------------------------------------------------
@@ -108,14 +105,15 @@ RUN cd revm && cargo build --release --package revme
 #
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0-noble AS dotnet-builder
-RUN git clone https://github.com/NethermindEth/nethermind --depth 1 --recurse-submodules
+RUN git clone https://github.com/NethermindEth/nethermind --depth 1
 
 RUN cd nethermind/src/Nethermind/Nethermind.Test.Runner && dotnet publish --self-contained true -r linux-x64 -c Release
 RUN mkdir /out && mv nethermind/src/Nethermind/artifacts/bin/Nethermind.Test.Runner/release_linux-x64 /out/neth
 
 # also txparse
 RUN cd nethermind/tools/TxParser && dotnet publish --self-contained true -r linux-x64 -c Release
-RUN mv /nethermind/tools/artifacts/publish/TxParser/release_linux-x64/  /out/neth.txparse
+# winds up at /out/neth/TxParser
+RUN cp -rT /nethermind/tools/artifacts/publish/TxParser/release_linux-x64/ /out/neth/
 
 #---------------------------------------------------------------
 # java-builder
@@ -154,24 +152,26 @@ RUN apt-get install -qy --no-install-recommends \
 	openjdk-21-jre \ 
 	libstdc++-13-dev \
 	pipx git curl gcc python3-dev pkg-config \
-	jq nano
+	jq nano \
+  && apt-get clean
 
 # Install execution-specs (EELS)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y 
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s  -- -y  --profile=minimal
 RUN git clone https://github.com/ethereum/execution-specs.git --branch forks/prague --depth 1
 RUN . "$HOME/.cargo/env"; PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/ pipx install './execution-specs/[test]'
 ENV EELS_BIN=/ethereum-spec-evm
 
 # Go-evmlab targets
-COPY --from=golang-builder /go/goevmlab/generic-fuzzer /usr/bin
-COPY --from=golang-builder /go/goevmlab/generic-generator /usr/bin
-COPY --from=golang-builder /go/goevmlab/checkslow  /usr/bin
-COPY --from=golang-builder /go/goevmlab/minimizer /usr/bin
-COPY --from=golang-builder /go/goevmlab/repro /usr/bin
-COPY --from=golang-builder /go/goevmlab/runtest /usr/bin
-COPY --from=golang-builder /go/goevmlab/tracediff /usr/bin
-COPY --from=golang-builder /go/goevmlab/traceview /usr/bin
-COPY --from=golang-builder /go/goevmlab/evms.test /usr/bin
+COPY --from=golang-builder /go/goevmlab/generic-fuzzer \
+  /go/goevmlab/generic-generator \
+  /go/goevmlab/checkslow \
+  /go/goevmlab/minimizer \
+  /go/goevmlab/repro \
+  /go/goevmlab/runtest \
+  /go/goevmlab/tracediff \
+  /go/goevmlab/traceview \
+  /go/goevmlab/evms.test \
+ /usr/bin/
 
 COPY --from=golang-builder /go/go-ethereum/build/bin/evm /gethvm
 ENV GETH_BIN=/gethvm
@@ -180,7 +180,7 @@ COPY --from=golang-builder /erigon_vm /erigon_vm
 COPY --from=golang-builder /libsilkworm_capi.so /lib/libsilkworm_capi.so
 ENV ERIG_BIN=/erigon_vm
 
-COPY --from=golang-builder /evmstate /nimbvm
+#COPY --from=golang-builder /evmstate /nimbvm
 ENV NIMB_BIN=/nimbvm
 
 COPY --from=debian-builder /evmone-statetest /evmone

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -194,8 +194,6 @@ COPY --from=dotnet-builder /out/neth /neth
 RUN ln -s /neth/nethtest /nethtest
 ENV NETH_BIN=/neth/nethtest
 
-COPY --from=dotnet-builder /out/neth.txparse /neth.txparse
-
 COPY --from=java-builder /out/evmtool /evmtool
 RUN ln -s /evmtool/bin/evmtool besu-vm
 ENV BESU_BIN=/evmtool/bin/evmtool


### PR DESCRIPTION
Before, it was at `3.45B`: 

```
holiman/omnifuzz   latest            1ad5c6d0de75   9 hours ago     3.45GB
```
Details:
```
user@debian-work:~$ docker history  1ad5c6d0de75 
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
1ad5c6d0de75   9 hours ago   ENTRYPOINT ["/bin/bash"]                        0B        buildkit.dockerfile.v0
<missing>      9 hours ago   ENV FUZZ_CLIENTS_PLAIN=--geth=/gethvm  --net…   0B        buildkit.dockerfile.v0
<missing>      9 hours ago   ENV FUZZ_CLIENTS=--gethbatch=/gethvm  --neth…   0B        buildkit.dockerfile.v0
<missing>      9 hours ago   COPY readme_docker.md /README.md # buildkit     1.47kB    buildkit.dockerfile.v0
<missing>      9 hours ago   ENV BESU_BIN=/evmtool/bin/evmtool               0B        buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c ln -s /evmtool/bin/evmtool be…   20B       buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /out/evmtool /evmtool # buildkit           200MB     buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /out/neth.txparse /neth.txparse # build…   172MB     buildkit.dockerfile.v0
<missing>      9 hours ago   ENV NETH_BIN=/neth/nethtest                     0B        buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c ln -s /neth/nethtest /nethtes…   14B       buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /out/neth /neth # buildkit                 265MB     buildkit.dockerfile.v0
<missing>      9 hours ago   ENV RETH_BIN=/revme                             0B        buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /revm/target/release/revme /revme # bui…   5.04MB    buildkit.dockerfile.v0
<missing>      9 hours ago   ENV EVMO_BIN=/evmone                            0B        buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /libevmone.so.* /lib/ # buildkit           1.02MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /evmone-statetest /evmone # buildkit       1.68MB    buildkit.dockerfile.v0
<missing>      9 hours ago   ENV NIMB_BIN=/nimbvm                            0B        buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /evmstate /nimbvm # buildkit               29.5MB    buildkit.dockerfile.v0
<missing>      9 hours ago   ENV ERIG_BIN=/erigon_vm                         0B        buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /libsilkworm_capi.so /lib/libsilkworm_c…   45.3MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /erigon_vm /erigon_vm # buildkit           64.8MB    buildkit.dockerfile.v0
<missing>      9 hours ago   ENV GETH_BIN=/gethvm                            0B        buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/go-ethereum/build/bin/evm /gethvm #…   33.9MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/evms.test /usr/bin # build…   11.2MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/traceview /usr/bin # build…   12MB      buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/tracediff /usr/bin # build…   12MB      buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/runtest /usr/bin # buildkit   18.9MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/repro /usr/bin # buildkit     17.2MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/minimizer /usr/bin # build…   17.2MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/checkslow /usr/bin # build…   17.1MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/generic-generator /usr/bin…   19.9MB    buildkit.dockerfile.v0
<missing>      9 hours ago   COPY /go/goevmlab/generic-fuzzer /usr/bin # …   19.2MB    buildkit.dockerfile.v0
<missing>      9 hours ago   ENV EELS_BIN=/ethereum-spec-evm                 0B        buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c . "$HOME/.cargo/env"; PIPX_HO…   117MB     buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c git clone https://github.com/…   6.24MB    buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c curl --proto '=https' --tlsv1…   1.21GB    buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c apt-get install -qy --no-inst…   1.02GB    buildkit.dockerfile.v0
<missing>      9 hours ago   RUN /bin/sh -c apt-get update -q # buildkit     21.1MB    buildkit.dockerfile.v0
<missing>      2 weeks ago   # debian.sh --arch 'amd64' out/ 'testing' '@…   120MB     debuerreotype 0.15
```
