### PR TITLE
dockerfile: use headless java

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -137,7 +137,6 @@ RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
 
 FROM debian:testing
 
-RUN apt-get update -q
 # nethtest requires libssl-dev
 # besu requires openjdk-21-jre
 # evmone requires GLIBC_2.38 (libstdc++-13-dev) (https://github.com/holiman/goevmlab/issues/144)
@@ -147,9 +146,10 @@ RUN apt-get update -q
 #   - gcc for building 'py-arkworks-bls12381', 
 #   - python3-dev for bulding 'lru-dict'
 #   - pkg-config (see https://github.com/ethereum/execution-specs/issues/1103)
-RUN apt-get install -qy --no-install-recommends \
+RUN apt-get update -q && \ 
+    apt-get install -qy --no-install-recommends \
 	libssl-dev  \
-	openjdk-21-jre \ 
+	openjdk-21-jre-headless \ 
 	libstdc++-13-dev \
 	pipx git curl gcc python3-dev pkg-config \
 	jq nano \


### PR DESCRIPTION
Before
```
REPOSITORY         TAG               IMAGE ID       CREATED         SIZE
holiman/omnifuzz   latest            097a31ebf296   6 minutes ago   2.65GB
```
This PR
```
REPOSITORY         TAG               IMAGE ID       CREATED             SIZE
holiman/omnifuzz   latest            b9ef0224946a   3 minutes ago       2.32GB
```
```
user@debian-work:~/workspace/goevmlab/docker$ docker history b9ef0224946a
IMAGE          CREATED          CREATED BY                                      SIZE      COMMENT
b9ef0224946a   6 minutes ago    ENTRYPOINT ["/bin/bash"]                        0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV FUZZ_CLIENTS_PLAIN=--geth=/gethvm  --net…   0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV FUZZ_CLIENTS=--gethbatch=/gethvm  --neth…   0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY readme_docker.md /README.md # buildkit     1.47kB    buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV BESU_BIN=/evmtool/bin/evmtool               0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    RUN /bin/sh -c ln -s /evmtool/bin/evmtool be…   20B       buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /out/evmtool /evmtool # buildkit           200MB     buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV NETH_BIN=/neth/nethtest                     0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    RUN /bin/sh -c ln -s /neth/nethtest /nethtes…   14B       buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /out/neth /neth # buildkit                 264MB     buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV RETH_BIN=/revme                             0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /revm/target/release/revme /revme # bui…   5.04MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV EVMO_BIN=/evmone                            0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /libevmone.so.* /lib/ # buildkit           1.02MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /evmone-statetest /evmone # buildkit       1.68MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV NIMB_BIN=/nimbvm                            0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /evmstate /nimbvm # buildkit               29.5MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV ERIG_BIN=/erigon_vm                         0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /libsilkworm_capi.so /lib/libsilkworm_c…   45.3MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /erigon_vm /erigon_vm # buildkit           64.8MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV GETH_BIN=/gethvm                            0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /go/go-ethereum/build/bin/evm /gethvm #…   33.9MB    buildkit.dockerfile.v0
<missing>      6 minutes ago    COPY /go/goevmlab/generic-fuzzer /go/goevmla…   145MB     buildkit.dockerfile.v0
<missing>      6 minutes ago    ENV EELS_BIN=/ethereum-spec-evm                 0B        buildkit.dockerfile.v0
<missing>      6 minutes ago    RUN /bin/sh -c . "$HOME/.cargo/env"; PIPX_HO…   117MB     buildkit.dockerfile.v0
<missing>      8 minutes ago    RUN /bin/sh -c git clone https://github.com/…   6.24MB    buildkit.dockerfile.v0
<missing>      8 minutes ago    RUN /bin/sh -c curl --proto '=https' --tlsv1…   578MB     buildkit.dockerfile.v0
<missing>      53 minutes ago   RUN /bin/sh -c apt-get update -q &&     apt-…   709MB     buildkit.dockerfile.v0
<missing>      2 weeks ago      # debian.sh --arch 'amd64' out/ 'testing' '@…   120MB     debuerreotype 0.15
```