### PR TITLE
docker: separate nimbus-eth1 out, remove rust after installation of eels

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,11 +53,13 @@ RUN cd erigon && mkdir /erigon/ && make evm && \
 #
 # NIMBUS-ETH1
 #
+# Nimbus-eth1 takes a humongous time to build, so it has been moved out to 
+# a standalone image, and built every once in a while. See Dockerfile.nimbus
 
-RUN apt-get update -q && apt-get install -qy --no-install-recommends make
-RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules && \
- cd nimbus-eth1 && make -j8 update && \
- make -j8 evmstate && cp ./tools/evmstate/evmstate /evmstate
+#RUN apt-get update -q && apt-get install -qy --no-install-recommends make
+#RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules && \
+# cd nimbus-eth1 && make -j8 update && \
+# make -j8 evmstate && cp ./tools/evmstate/evmstate /evmstate
 
 
 #---------------------------------------------------------------
@@ -135,7 +137,7 @@ RUN mkdir /out && mv besu/ethereum/evmtool/build/install/evmtool /out/evmtool
 # Main non-builder
 #
 
-FROM debian:testing
+FROM debian:testing-slim
 
 # nethtest requires libssl-dev
 # besu requires openjdk-21-jre
@@ -156,9 +158,14 @@ RUN apt-get update -q && \
   && apt-get clean
 
 # Install execution-specs (EELS)
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s  -- -y  --profile=minimal
 RUN git clone https://github.com/ethereum/execution-specs.git --branch forks/prague --depth 1
-RUN . "$HOME/.cargo/env"; PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/ pipx install './execution-specs/[test]'
+
+#   To install EELS, we temporarily install rust, which is required for building parts of eels, 
+#   and after building, we delete it again
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s  -- -y  --profile=minimal && \
+  . "$HOME/.cargo/env"; PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/ pipx install './execution-specs/[test]' && \
+  rm -rf /root/.rustup && rm -rf /root/.cargo
+
 ENV EELS_BIN=/ethereum-spec-evm
 
 # Go-evmlab targets
@@ -180,7 +187,7 @@ COPY --from=golang-builder /erigon_vm /erigon_vm
 COPY --from=golang-builder /libsilkworm_capi.so /lib/libsilkworm_capi.so
 ENV ERIG_BIN=/erigon_vm
 
-COPY --from=golang-builder /evmstate /nimbvm
+COPY --from=holiman/nimbus:latest /evmstate /nimbvm
 ENV NIMB_BIN=/nimbvm
 
 COPY --from=debian-builder /evmone-statetest /evmone

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,7 +59,7 @@ RUN cd erigon && mkdir /erigon/ && make evm && \
 #RUN apt-get update -q && apt-get install -qy --no-install-recommends make
 #RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules && \
 # cd nimbus-eth1 && make -j8 update && \
-# make -j8 evmstate && cp ./tools/evmstate/evmstate /evmstate
+# make -j8 evmstate && cp ./tools/evmstate/evmstate /nimbvm
 
 
 #---------------------------------------------------------------
@@ -187,7 +187,7 @@ COPY --from=golang-builder /erigon_vm /erigon_vm
 COPY --from=golang-builder /libsilkworm_capi.so /lib/libsilkworm_capi.so
 ENV ERIG_BIN=/erigon_vm
 
-COPY --from=holiman/nimbus:latest /evmstate /nimbvm
+COPY --from=holiman/nimbus:latest /nimbvm /nimbvm
 ENV NIMB_BIN=/nimbvm
 
 COPY --from=debian-builder /evmone-statetest /evmone

--- a/docker/Dockerfile.nimbus
+++ b/docker/Dockerfile.nimbus
@@ -1,0 +1,12 @@
+FROM debian:testing-slim as builder
+
+RUN apt update \
+ && apt -y install curl build-essential git-lfs librocksdb-dev \
+ && apt-get clean
+
+# RUN apt-get update -q && apt-get install -qy --no-install-recommends make
+
+RUN git clone -j8 https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules=':!/tests/**'
+#RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules=
+RUN cd nimbus-eth1 && make -j8 update 
+RUN cd nimbus-eth1 && make -j8 evmstate && cp ./tools/evmstate/evmstate /nimbvm

--- a/docker/Dockerfile.nimbus
+++ b/docker/Dockerfile.nimbus
@@ -4,9 +4,9 @@ RUN apt update \
  && apt -y install curl build-essential git-lfs librocksdb-dev \
  && apt-get clean
 
-# RUN apt-get update -q && apt-get install -qy --no-install-recommends make
-
 RUN git clone -j8 https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules=':!/tests/**'
-#RUN git clone https://github.com/status-im/nimbus-eth1.git --depth 1 --recurse-submodules=
 RUN cd nimbus-eth1 && make -j8 update 
 RUN cd nimbus-eth1 && make -j8 evmstate && cp ./tools/evmstate/evmstate /nimbvm
+
+FROM debian:testing
+COPY --from=builder /nimbvm /nimbvm

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ clients. To fix that, see [resource limiting](https://docs.docker.com/build/buil
 ```
 # /etc/buildkitd.toml
 [worker.oci]
-  max-parallelism = 4
+  max-parallelism = 1
 ```
 ```
  docker buildx create --use \
@@ -19,11 +19,28 @@ clients. To fix that, see [resource limiting](https://docs.docker.com/build/buil
   --driver docker-container \
   --config /etc/buildkitd.toml
 ```
-and then build
+
+## Building
+
+Building the main `holiman/omnifuzz` image:
 ```
-docker buildx   build   --progress=plain -t holiman/omnifuzz .
+docker buildx build --progress=plain --load --push -t holiman/omnifuzz .
 ```
 
-## The container itself
+However, the `nimbus-eth1` client takes so long to build, so it's been moved into a separate container: `holiman/nimbus`:
+```
+docker buildx build --progress=plain --load  --push -t holiman/nimbus -f Dockerfile.nimbus  .
+```
+In order to update _everything_, the `holiman/nimbus`-image must first be rebuilt, then the regular `holiman/omnifuzz`-client needs
+to be rebuilt. And the caches needs clearing: 
+```
+docker system prune -af && docker buildx prune -f
+docker buildx build --progress=plain --load  --push -t holiman/nimbus -f Dockerfile.nimbus  .
+curl -d "Docker build #1 done"  ntfy.sh/yourchannel
+docker buildx build --progress=plain --push --load  -t holiman/omnifuzz  .
+curl -d "Docker build #2 done"  ntfy.sh/yourchannel
+```
+
+## Running the container
 
 There's more information in the [in-docker-readme](readme_docker.md)


### PR DESCRIPTION
This PR splits away the `nimbus-eth1` evm client into a separate image, and also cleans up the rust stuff in the main container. 

The split makes it so we don't have to rebuild `nimbus-eth1` each time the 'main' is rebuilt (it takes a huge amount of time), and the latter change makes the image a lot++ smaller. 

With this PR, the size has gone from `2.65GB` to `1.66GB`

```
REPOSITORY         TAG               IMAGE ID       CREATED             SIZE
holiman/omnifuzz   latest            3a384320be60   About an hour ago   1.66GB
holiman/nimbus     latest            c9e46dc09510   About an hour ago   151MB
```
```
user@debian-work:~/workspace/goevmlab/docker$ docker history holiman/omnifuzz
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
3a384320be60   About an hour ago   ENTRYPOINT ["/bin/bash"]                        0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV FUZZ_CLIENTS_PLAIN=--geth=/gethvm  --net…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   ENV FUZZ_CLIENTS=--gethbatch=/gethvm  --neth…   0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY readme_docker.md /README.md # buildkit     1.47kB    buildkit.dockerfile.v0
<missing>      About an hour ago   ENV BESU_BIN=/evmtool/bin/evmtool               0B        buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c ln -s /evmtool/bin/evmtool be…   20B       buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /out/evmtool /evmtool # buildkit           200MB     buildkit.dockerfile.v0
<missing>      About an hour ago   ENV NETH_BIN=/neth/nethtest                     0B        buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c ln -s /neth/nethtest /nethtes…   14B       buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /out/neth /neth # buildkit                 264MB     buildkit.dockerfile.v0
<missing>      About an hour ago   ENV RETH_BIN=/revme                             0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /revm/target/release/revme /revme # bui…   5.04MB    buildkit.dockerfile.v0
<missing>      About an hour ago   ENV EVMO_BIN=/evmone                            0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /libevmone.so.* /lib/ # buildkit           1.02MB    buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /evmone-statetest /evmone # buildkit       1.68MB    buildkit.dockerfile.v0
<missing>      About an hour ago   ENV NIMB_BIN=/nimbvm                            0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /nimbvm /nimbvm # buildkit                 31.3MB    buildkit.dockerfile.v0
<missing>      About an hour ago   ENV ERIG_BIN=/erigon_vm                         0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /libsilkworm_capi.so /lib/libsilkworm_c…   45.3MB    buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /erigon_vm /erigon_vm # buildkit           64.8MB    buildkit.dockerfile.v0
<missing>      About an hour ago   ENV GETH_BIN=/gethvm                            0B        buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /go/go-ethereum/build/bin/evm /gethvm #…   33.9MB    buildkit.dockerfile.v0
<missing>      About an hour ago   COPY /go/goevmlab/generic-fuzzer /go/goevmla…   145MB     buildkit.dockerfile.v0
<missing>      About an hour ago   ENV EELS_BIN=/ethereum-spec-evm                 0B        buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c curl --proto '=https' --tlsv1…   119MB     buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c git clone https://github.com/…   6.25MB    buildkit.dockerfile.v0
<missing>      About an hour ago   RUN /bin/sh -c apt-get update -q &&     apt-…   660MB     buildkit.dockerfile.v0
<missing>      2 weeks ago         # debian.sh --arch 'amd64' out/ 'testing' '@…   78.6MB    debuerreotype 0.15
```
