### PR TITLE
fuzzing: add optional trace limit field

### DIFF
--- a/cmd/generic-generator/main.go
+++ b/cmd/generic-generator/main.go
@@ -171,7 +171,7 @@ func createTests(conf *config) error {
 		// Generate new code
 		base := conf.factory()
 		// Get new state root and logs hash
-		if err := base.Fill(traceOutput); err != nil {
+		if err := base.Fill(traceOutput, 0); err != nil {
 			close()
 			return err
 		}

--- a/common/utils.go
+++ b/common/utils.go
@@ -900,7 +900,7 @@ func ConvertToStateTest(name, fork string, alloc types.GenesisAlloc, gasLimit ui
 	}
 	mkr.SetTx(tx)
 	mkr.SetPre(&fuzzGenesisAlloc)
-	if err := mkr.Fill(nil); err != nil {
+	if err := mkr.Fill(nil, 0); err != nil {
 		return err
 	}
 	gst := mkr.ToGeneralStateTest(name)

--- a/examples/analysisAttack/main.go
+++ b/examples/analysisAttack/main.go
@@ -262,7 +262,7 @@ func convertToStateTest(name, fork string, alloc types.GenesisAlloc, gasLimit ui
 	}
 	mkr.SetTx(tx)
 	mkr.SetPre(&fuzzGenesisAlloc)
-	if err := mkr.Fill(nil); err != nil {
+	if err := mkr.Fill(nil, 0); err != nil {
 		return err
 	}
 	gst := mkr.ToGeneralStateTest(name)

--- a/examples/create2_bug/main.go
+++ b/examples/create2_bug/main.go
@@ -68,7 +68,7 @@ func makeTest() error {
 		return err
 	}
 	defer traceOut.Close()
-	if err := gst.Fill(traceOut); err != nil {
+	if err := gst.Fill(traceOut, 0); err != nil {
 		return err
 	}
 	t := gst.ToGeneralStateTest("tstore_test-1")

--- a/examples/loopAttack/main.go
+++ b/examples/loopAttack/main.go
@@ -250,7 +250,7 @@ func convertToStateTest(name, fork string, alloc types.GenesisAlloc, gasLimit ui
 	}
 	mkr.SetTx(tx)
 	mkr.SetPre(&fuzzGenesisAlloc)
-	if err := mkr.Fill(nil); err != nil {
+	if err := mkr.Fill(nil, 0); err != nil {
 		return err
 	}
 	gst := mkr.ToGeneralStateTest(name)

--- a/examples/selfdestruct_2929/main.go
+++ b/examples/selfdestruct_2929/main.go
@@ -209,7 +209,7 @@ func runit() error {
 	mkr.SetTx(tx)
 
 	mkr.SetPre(&fuzzGenesisAlloc)
-	if err := mkr.Fill(os.Stdout); err != nil {
+	if err := mkr.Fill(os.Stdout, 0); err != nil {
 		return err
 	}
 

--- a/examples/tstore_bug-2/main.go
+++ b/examples/tstore_bug-2/main.go
@@ -86,7 +86,7 @@ func makeTest() error {
 		return err
 	}
 	defer traceOut.Close()
-	if err := gst.Fill(traceOut); err != nil {
+	if err := gst.Fill(traceOut, 0); err != nil {
 		return err
 	}
 	t := gst.ToGeneralStateTest("tstore_test-2")

--- a/examples/tstore_bug/main.go
+++ b/examples/tstore_bug/main.go
@@ -87,7 +87,7 @@ func makeTest() error {
 		return err
 	}
 	defer traceOut.Close()
-	if err := gst.Fill(traceOut); err != nil {
+	if err := gst.Fill(traceOut, 0); err != nil {
 		return err
 	}
 	t := gst.ToGeneralStateTest("tstore_test-1")

--- a/fuzzing/statetest_maker.go
+++ b/fuzzing/statetest_maker.go
@@ -189,8 +189,9 @@ func (g *GstMaker) EnableFork(fork string) {
 }
 
 // Fill uses go-ethereum internally to determine the state root and logs, and optionally
-// outputs the trace to the given writer (if non-nil)
-func (g *GstMaker) Fill(traceOutput io.Writer) error {
+// outputs the trace to the given writer (if non-nil). The limit caps the size of the
+// trace output; zero means unlimited.
+func (g *GstMaker) Fill(traceOutput io.Writer, limit int) error {
 
 	test, err := g.ToStateTest()
 	if err != nil {
@@ -199,7 +200,7 @@ func (g *GstMaker) Fill(traceOutput io.Writer) error {
 	subtest := test.Subtests()[0]
 	cfg := vm.Config{}
 	if traceOutput != nil {
-		cfg.Tracer = logger.NewJSONLogger(&logger.Config{}, traceOutput)
+		cfg.Tracer = logger.NewJSONLogger(&logger.Config{Limit: limit}, traceOutput)
 	}
 	state, root, _, err := test.RunNoVerify(subtest, cfg, false, rawdb.HashScheme)
 	if err != nil {


### PR DESCRIPTION
Small PR to expose the limit we have for tracing in geth, makes it easier to filter out bytecodes that overload a  fuzzer.